### PR TITLE
Update condarc

### DIFF
--- a/condarc
+++ b/condarc
@@ -37,7 +37,7 @@ allow_softlinks: False
 # change ps1 when using activate (default True)
 changeps1: False
 
-# use pip when installing and listing packages (default True)
+# use pip when listing packages (default True)
 use_pip: False
 
 # binstar.org upload (not defined here means ask)


### PR DESCRIPTION
# use pip when listing packages

From the conda changelog
- limited pip integration to `conda list`, that means
  `conda install` no longer calls `pip install` # !!
  https://github.com/conda/conda/blob/master/CHANGELOG.txt#L19

P
