### PR TITLE
Fix condarc example to match conda-build code

### DIFF
--- a/condarc
+++ b/condarc
@@ -72,4 +72,5 @@ track_features:
 # Conda Build Options
 conda-build:
   # Build output root directory. (default <CONDA_PREFIX>/conda-bld/)
+  # This can also be set with the CONDA_BLD_PATH environment variable.
   root-dir: ~/conda-builds


### PR DESCRIPTION
The keyword to specify the output build directory changed from `build_dest` to `root-dir` (in conda-build version 1.3.2) but the example `condarc` file was not updated.
