### PR TITLE
Fix typo in bdist_conda

### DIFF
--- a/docs/source/bdist_conda.rst
+++ b/docs/source/bdist_conda.rst
@@ -17,7 +17,7 @@ must set ``distclass=distutils.command.bdist_conda.CondaDistribution`` in
 .. note::
 
    If you use ``setuptools``, you must import ``setuptools`` *before*
-   importing ``distutils.commands.bdist_conda``, as ``setuptools``
+   importing ``distutils.command.bdist_conda``, as ``setuptools``
    monkeypatches ``distutils.dist.Distribution``.
 
 Notes


### PR DESCRIPTION
The note about import order uses `commands` (with an `s`) in the `distutils` import; it should be `command`
