### PR TITLE
Docs tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ build/
 docs/source/commands/
 *.swp
 __pycache__
-.idea  # Pycharm
+
+# Pycharm
+.idea
 env

--- a/docs/source/admin.rst
+++ b/docs/source/admin.rst
@@ -1,15 +1,13 @@
-========================================================================
- Administrative channel management for a centralized conda installation
-========================================================================
+=================================
+System-wide channel configuration
+=================================
 
 By default, conda (and all packages it installs, including Anaconda) installs
 locally with a user-specific configuration. No administrative privileges are
-required, and no upstream files or other users are affected by the
-installation.
+required, and no upstream files or other users are affected by the installation.
 
 However, it is also possible to install conda (and packages) in an
-admin-controlled location that a group of users have access to. In this
-configuration, each user may use the central conda installation with a
+admin-controlled location that a group of users have access to. In thisconfiguration, each user may use the central conda installation with a
 personalized configuration specified by a .condarc file located in their $HOME
 directory. This user configuration is governed by a "system" .condarc file
 located in the top-level conda installation directory given by ``$PREFIX``

--- a/docs/source/admin.rst
+++ b/docs/source/admin.rst
@@ -1,5 +1,5 @@
 =================================
-System-wide channel configuration
+System-wide Channel Configuration
 =================================
 
 By default, conda (and all packages it installs, including Anaconda) installs

--- a/docs/source/build-commands.rst
+++ b/docs/source/build-commands.rst
@@ -1,6 +1,6 @@
-======================
- conda-build commands
-======================
+=====================================
+Command reference (building packages)
+=====================================
 
 The following commands are part of the ``conda-build`` package, which can be
 installed with ``conda install conda-build``.

--- a/docs/source/build-commands.rst
+++ b/docs/source/build-commands.rst
@@ -1,5 +1,5 @@
 =====================================
-Command reference (building packages)
+Command Reference (Building Packages)
 =====================================
 
 The following commands are part of the ``conda-build`` package, which can be

--- a/docs/source/build.rst
+++ b/docs/source/build.rst
@@ -1,6 +1,6 @@
 .. _build:
 
-conda build Recipe Reference
+Conda build recipe reference
 ============================
 
 Building a package requires a recipe.  A recipe is flat directory which
@@ -43,7 +43,6 @@ recipes for common repositories, such as
 
 The meta.yaml file
 ------------------
-
 
 All the metadata in the recipe is specified in the ``meta.yaml`` file. All
 sections are optional except for package/name and package/version.
@@ -492,8 +491,8 @@ Pre/Post link/unlink scripts
 ----------------------------
 .. TODO: Add post-unlink
 
-You can add scripts `pre-link.sh`, `post-link.sh`, or `pre-unlink.sh` (or
-`.bat` for Windows) to the recipe, which will be run before the package is
+You can add scripts ``pre-link.sh``, ``post-link.sh``, or ``pre-unlink.sh`` (or
+``.bat`` for Windows) to the recipe, which will be run before the package is
 installed, after it is installed, and before it is removed, respectively. If
 these scripts exit nonzero the installation/removal will fail.
 

--- a/docs/source/build.rst
+++ b/docs/source/build.rst
@@ -1,6 +1,6 @@
 .. _build:
 
-Conda build recipe reference
+Conda Build Recipe Reference
 ============================
 
 Building a package requires a recipe.  A recipe is flat directory which

--- a/docs/source/build_tutorials.rst
+++ b/docs/source/build_tutorials.rst
@@ -1,5 +1,5 @@
 =================
- Build tutorials
+ Build Tutorials
 =================
 
 .. toctree::

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -1,5 +1,5 @@
 ===================================
-Command Reference (package manager)
+Command Reference (Package Manager)
 ===================================
 
 Conda provides many commands for managing packages and environments.  The

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -29,27 +29,3 @@ installed with ``conda install conda-build``.
    :maxdepth: 2
 
    commands/build/*
-
-conda-pip rosetta stone
-=======================
-If you've used pip and virtualenv in the past, you can use conda to perform the operations you are used to.
-
-=====================================   =======================================================   ===========================================================
-Operation                               Pip Command                                               Conda Command
-=====================================   =======================================================   ===========================================================
-Install a package                       ``pip install $PACKAGE_NAME``                             ``conda install $PACKAGE_NAME``
-Uninstall a package                     ``pip uninstall $PACKAGE_NAME``                           ``conda remove --name $ENVIRONMENT_NAME $PACKAGE_NAME``
-Create an environment                   ``cd $ENV_BASE_DIR; virtualenv $ENVIRONMENT_NAME``        ``conda create --name $ENVIRONMENT_NAME python``
-Activate an environment                 ``source $ENV_BASE_DIR/$ENVIRONMENT_NAME/bin/activate``   ``source activate $ENVIRONMENT_NAME``
-Deactivate an environment               ``deactivate``                                            ``source deactivate``
-Search available packages               ``pip search $SEARCH_TERM``                               ``conda search $SEARCH_TERM``
-Install package from specific source    ``pip install --index-url $URL $PACKAGE_NAME``            ``conda install --channel $URL $PACKAGE_NAME``
-List installed packages                 ``pip list``                                              ``conda list --name $ENVIRONMENT_NAME``
-Create requirements file                ``pip freeze``                                            ``conda list --export``
-Update a package                        ``pip install --upgrade $PACKAGE_NAME``                   ``conda update --name $PACKAGE_NAME``
-=====================================   =======================================================   ===========================================================
-
-.. Show what files a package has installed ``pip show --files $PACKAGE_NAME``  not possible
-.. Print details on an individual package ``pip show $PACKAGE_NAME``  not possible
-.. List available environments   not possible   ``conda info -e``
-.. #user will want to pass that through ``tail -n +3 | awk '{print $1;}'``

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -1,6 +1,6 @@
-=================
-Command Reference
-=================
+===================================
+Command Reference (package manager)
+===================================
 
 Conda provides many commands for managing packages and environments.  The
 following pages have help for each command. The help for a command can also be
@@ -17,15 +17,3 @@ Contents:
    :maxdepth: 2
 
    commands/*
-
-conda-build commands
-====================
-
-The following commands are part of the ``conda-build`` package, which can be
-installed with ``conda install conda-build``.
-
-.. toctree::
-   :glob:
-   :maxdepth: 2
-
-   commands/build/*

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Conda'
-copyright = u'2014, Continuum Analytics'
+copyright = u'2014‒2015, Continuum Analytics'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Conda'
-copyright = u'2014‒2015, Continuum Analytics'
+copyright = u'2015, Continuum Analytics'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -1,9 +1,12 @@
-
-.. _config:
-
--------------
+=============
 Configuration
--------------
+=============
+
+.. toctree::
+   :maxdepth: 1
+
+   admin
+   tab-completion
 
 There is very little user configuration that conda requires; however, conda
 will read minimal configuration from a ``$HOME/.condarc`` file, if it is
@@ -30,33 +33,3 @@ Here is an example:
 
 You can use the ``conda config`` command to modify configuration options in
 ``.condarc`` from the command line.
-
---------------
-Tab Completion
---------------
-
-``conda`` supports tab completion in bash shells via the ``argcomplete``
-package. First, make sure that ``argcomplete`` is installed
-
-.. code-block:: bash
-
-   $ conda install argcomplete
-
-Then add
-
-.. code-block:: bash
-
-   eval "$(register-python-argcomplete conda)"
-
-to your bash profile. You can test that it works by opening a new terminal
-window and typing
-
-.. code-block:: bash
-
-   $ conda ins<TAB>
-
-It should complete to
-
-.. code-block:: bash
-
-   $ conda install

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,14 +1,12 @@
-==================
+========
 Examples
-==================
+========
 
-Below are a few examples using conda commands with a variety of optional arguments.
-
-Contents:
+Below are a few examples using conda commands with a variety of optional
+arguments.
 
 .. toctree::
    :maxdepth: 7
 
    examples/information
    examples/basic
-   examples/advanced

--- a/docs/source/examples/advanced.rst
+++ b/docs/source/examples/advanced.rst
@@ -1,9 +1,0 @@
-===========================
-Advanced Package Management
-===========================
-
-.. warning::
-    These conda commands perform low level operations on Anaconda installations and environments, and can potentially leave Anaconda environments in inconsistent or unusable states. They should not be needed for any common tasks.
-
-.. toctree::
-

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,9 +1,9 @@
-=========
-Conda FAQ
-=========
+==========================
+Frequently asked questions
+==========================
 
-Table of contents:
-==================
+Contents
+========
 
 #. :ref:`general-questions`
 #. :ref:`getting-help`

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,5 +1,5 @@
 ==========================
-Frequently asked questions
+Frequently Asked Questions
 ==========================
 
 Contents

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,6 @@ Installing packages/environments
    examples
    pip-comparison
    config
-   admin
    faq
    troubleshooting
    commands

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,14 +3,15 @@ Conda
 =====
 
 
-Conda is a cross-platform, Python-agnostic binary package manager. It is the package manager used by Anaconda
-installations, but it may be used for other systems as well. Conda makes environments first-class citizens, making it
-easy to create independent environments even for C libraries. Conda is written entirely in Python, and is BSD licensed
-open source.
+Conda is a cross-platform, Python-agnostic binary package manager. It is the package manager used by `Anaconda
+<https://store.continuum.io/cshop/anaconda/>`_ installations, but it may be used for other systems as well. Conda makes
+environments first-class citizens, making it easy to create independent environments even for C libraries. Conda is
+written entirely in Python, and is `BSD licensed open source <http://opensource.org/licenses/bsd-license.php>`_.
 
 
-User Guide
-----------
+Installing packages/environments
+--------------------------------
+
 .. toctree::
    :maxdepth: 1
 
@@ -21,19 +22,19 @@ User Guide
    faq
    troubleshooting
    config
-   build
-   build_tutorials
    admin
-   custom-channels
+   commands
 
 
-Reference Guide
----------------
+Building packages
+-----------------
 
 .. toctree::
    :maxdepth: 1
 
-   commands
+   build_tutorials
+   build
+   custom-channels
    build-commands
    spec
    travis
@@ -42,29 +43,11 @@ Reference Guide
 Presentations & Blog Posts
 --------------------------
 
-`Packaging and Deployment with conda - Travis Oliphant <https://speakerdeck.com/teoliphant/packaging-and-deployment-with-conda>`_
-
-`Python 3 support in Anaconda - Ilan Schnell <http://continuum.io/blog/anaconda-python-3>`_
-
-`New Advances in conda - Ilan Schnell <http://continuum.io/blog/new-advances-in-conda>`_
-
-`Python Packages and Environments with conda - Bryan Van de Ven <http://continuum.io/blog/conda>`_
-
-`Advanced features of Conda, part 1 - Aaron Meurer <http://continuum.io/blog/advanced-conda-part-1>`_
-
-Requirements
-------------
-
-* python 2.7, 3.3, or 3.4
-* pycosat
-* pyyaml
-* requests
-
-
-License Agreement
------------------
-
-conda is distributed under the `BSD license <http://opensource.org/licenses/bsd-license.php>`_.
+- `Packaging and Deployment with conda - Travis Oliphant <https://speakerdeck.com/teoliphant/packaging-and-deployment-with-conda>`_
+- `Python 3 support in Anaconda - Ilan Schnell <http://continuum.io/blog/anaconda-python-3>`_
+- `New Advances in conda - Ilan Schnell <http://continuum.io/blog/new-advances-in-conda>`_
+- `Python Packages and Environments with conda - Bryan Van de Ven <http://continuum.io/blog/conda>`_
+- `Advanced features of Conda, part 1 - Aaron Meurer <http://continuum.io/blog/advanced-conda-part-1>`_
 
 
 Indices and tables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,9 +21,9 @@ Installing packages/environments
    examples
    pip-comparison
    config
+   admin
    faq
    troubleshooting
-   admin
    commands
 
 
@@ -36,11 +36,11 @@ Building packages
    build_tutorials
    build
    custom-channels
-   build-commands
    package-name
    spec
    travis
    bdist_conda
+   build-commands
 
 Presentations & Blog Posts
 --------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,76 +1,22 @@
-.. conda documentation master file, created by
-   sphinx-quickstart on Sat Nov  3 16:08:12 2012.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 =====
 Conda
 =====
 
 
-The `conda` command is the primary interface for managing `Anaconda
-<http://docs.continuum.io/anaconda/index.html>`_ installations. It can query
-and search the Anaconda package index and current Anaconda installation,
-create new conda environments, and install and update packages into existing
-conda environments.
-
-
-Getting Started
----------------
-
-To demonstrate the ease of a typical conda workflow, we will create a conda environment
-with a version of `NumPy <http://www.numpy.org>`_ different from the default version.
-
-First, we will check our system's Numpy version
-
-.. code-block:: bash
-
-    $ python
-    Python 2.7.5 |Anaconda 1.6.1 (x86_64)| (default, Jun 28 2013, 22:20:13)
-    [GCC 4.0.1 (Apple Inc. build 5493)] on darwin
-    Type "help", "copyright", "credits" or "license" for more information.
-    >>> import numpy
-    >>> numpy.__version__
-    '1.7.1'
-
-Next we will create a conda environment using a different version of NumPy
-
-.. code-block:: none
-
-    $ conda create -p ~/anaconda/envs/test numpy=1.6 anaconda
-
-    Package plan for creating environment at /Users/maggie/anaconda/envs/test:
-
-    The following packages will be downloaded:
-
-    [      COMPLETE      ] |#################################################| 100%
-
-Now we change our **PATH** variable to point to the new environment
-
-.. code-block:: bash
-
-    $ export PATH=~/anaconda/envs/test/bin/:$PATH
-
-Finally, we check the version of Numpy again
-
-.. code-block:: python
-
-    $ python
-    Python 2.7.5 |Anaconda 1.6.1 (x86_64)| (unknown, Jan 10 2013, 12:19:03)
-    [GCC 4.0.1 (Apple Inc. build 5493)] on darwin
-    Type "help", "copyright", "credits" or "license" for more information.
-    >>> import numpy
-    >>> numpy.__version__
-    '1.6.2'
+Conda is a cross-platform, Python-agnostic binary package manager. It is the package manager used by Anaconda
+installations, but it may be used for other systems as well. Conda makes environments first-class citizens, making it
+easy to create independent environments even for C libraries. Conda is written entirely in Python, and is BSD licensed
+open source.
 
 
 User Guide
 ----------
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    intro
    installation
+   quick-start
    examples
    faq
    troubleshooting
@@ -85,7 +31,7 @@ Reference Guide
 ---------------
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    commands
    build-commands

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Installing packages/environments
    installation
    quick-start
    examples
+   pip-comparison
    faq
    troubleshooting
    config

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,9 +20,9 @@ Installing packages/environments
    quick-start
    examples
    pip-comparison
+   config
    faq
    troubleshooting
-   config
    admin
    commands
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,7 @@ Building packages
    build
    custom-channels
    build-commands
+   package-name
    spec
    travis
    bdist_conda

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -9,8 +9,8 @@ Conda can also be installed as a stand-alone packages known as *Miniconda*. Inst
 available on `the Conda site <http://conda.pydata.org/miniconda.html#miniconda>`_.
 
 
-Silent installation
--------------------
+Silent/unattended installation
+------------------------------
 
 Silent installation of Miniconda can be used for deployment or testing or building services such as Travis CI and
 Appveyor.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -19,7 +19,7 @@ Appveyor.
 The lastest version of the Miniconda installer can be found `in the repo <http://repo.continuum.io/miniconda/>`_. In any
 case, an out of date installation can be updated with a simple:
 
-.. code-block:: console
+.. code-block:: bash
 
     conda update conda
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -24,6 +24,19 @@ libraries, Python modules, executable programs, or other components. Conda
 keeps track of dependencies between packages and platform specifics, making it
 simple to install sets of packages.
 
+A typical package file name could be something like:
+
+    ``gevent-websocket-0.3.6-py27_0.tar.bz2``
+
+    <package-name>-<version>-<build_string>.tar.bz2
+
+.. seealso::
+
+   - `Installing a package <commands/conda-install>`_
+   - `Updating packages <conda-update.html>`_
+   - :doc:`package-name`
+   - :doc:`spec`
+
 
 .. _meta_package:
 
@@ -55,8 +68,12 @@ However, conda has a notion of `locations` which are also simply directories
 that are known to conda, and contain environments within. Conda environments
 created in such locations are said to be "known", and can be displayed for
 easy reference. Conda has a default system location, but additional locations
-may be specified (see `Directory Structure`_ and :ref:`config`, respectively,
-for more details).
+may be specified.
+
+.. seealso::
+
+   - `Creating environments <commands/conda-create>`_
+   - :doc:`config`
 
 
 .. _channel:
@@ -85,7 +102,7 @@ repositories. A channel is a simple URL to a folder containing conda packages.
 Conda comes with a default set of channels to search and install packages
 from. However, these can be changed easily, additional default channels can
 be configured or a specific channel can be specified *ad hoc* when installing a
-package (see :ref:`config` for details).
+package (see :doc:`config` for details).
 
 Channels can be private, public, based on a single machine or local network or
 hosted online.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -11,20 +11,13 @@ Conda is a cross-platform, Python-agnostic binary package manager. Conda can:
   packages into new and existing environments.
 
 
-Conda Overview
---------------
-
 .. _package:
 .. index::
     pair: terminology; package
 
-.. _environment:
-.. index::
-    pair: terminology; environment
-
 
 Packages
-~~~~~~~~
+--------
 
 A conda `package` is a binary archive (tarball) containing system-level
 libraries, Python modules, executable programs, or other components. Conda
@@ -32,15 +25,30 @@ keeps track of dependencies between packages and platform specifics, making it
 simple to install sets of packages.
 
 
+.. _meta_package:
+
+Meta-Packages
+-------------
+
+conda also provides the notion of `meta-packages`.  A meta-package is a conda
+package that only has dependencies, no files. An easy way to make a
+meta-package is with the ``conda metapackage`` command.
+
+
+.. _environment:
+.. index::
+    pair: terminology; environment
+
 Environments
-~~~~~~~~~~~~
+------------
 
 A `conda environment` is a filesystem directory that contains a specific
-collection of conda packages.  As a concrete example, you might want to
-have one environment that provides NumPy 1.7, and another environment that
-provides NumPy 1.6 for legacy testing.  conda makes this kind of mixing
-and matching easy.  To begin using an environment, simply set
-your **PATH** variable to point to its `bin` directory.
+collection of conda packages.  As a concrete example, you might want to have one
+environment that provides NumPy 1.7, and another environment that provides NumPy
+1.6 for legacy testing.  conda makes this kind of mixing and matching easy. To
+begin using an environment, simply set your ``PATH`` variable to point to its
+`bin` directory. This can also be done using the ``source activate`` (Linux,
+OS X) or ``activate`` (Windows) command.
 
 Since conda environments are simply directories, they may be created anywhere.
 However, conda has a notion of `locations` which are also simply directories
@@ -69,7 +77,7 @@ for more details).
 
 
 Channels
-~~~~~~~~
+--------
 
 Conda packages can be installed from local or remote ``channels`` within
 repositories. A channel is a simple URL to a folder containing conda packages.
@@ -92,12 +100,6 @@ Continuum provides the following standard channels:
 To view all available packages, you can use ``conda search``.  See the
 :ref:`search command examples <search_example>` for more information.
 
-Once a conda package has been downloaded, it is said to be "locally available".
-A locally available package that has been linked into an conda environment
-is said to be "linked". Conversely, unlinking a package from an environment
-causes it to be "unlinked".
-
-
 .. _location:
 .. index::
     pair: terminology; location
@@ -106,104 +108,22 @@ causes it to be "unlinked".
 .. index::
     pair: terminology; known
 
+Once a conda package has been downloaded, it is said to be "locally available".
+A locally available package that has been linked into an conda environment
+is said to be "linked". Conversely, unlinking a package from an environment
+causes it to be "unlinked".
 
-Package Naming Conventions
---------------------------
-
-Names and versions of software packages do not follow any prescribed rules.
-However, in order to facilitate communication and documentation,
-conda employs the following naming conventions with respect to packages:
-
-.. _package_name:
-.. index::
-    pair: terminology; package name
-    seealso: name; package name
-
-**package name**
-    The name of a package, without any reference to a particular version.
-    Conda package names are normalized, and may contain only lowercase alpha
-    characters, numeric digits, underscores, or hyphens.  In usage
-    documentation, these will be referred to by `package_name`.
-
-.. _package_version:
-.. index::
-    pair: terminology; package version
-    seealso: name; package version
-
-**package version**
-    A version number or string, often similar to *X.Y* or *X.Y.Z*, but may
-    take other forms as well.
-
-.. _build_string:
-.. index::
-    pair: terminology; build string
-    seealso: name; build string
-
-**build string**
-    An arbitrary string that identifies a particular build of a package for
-    conda.  It may contain suggestive mnemonics but these are subject to
-    change and should not be relied upon or attempted to be parsed for any
-    specific information.
-
-.. _canonical_name:
-.. index::
-    pair: terminology; canonical name
-    seealso: name; canonical name
-
-**canonical name**
-    The canonical name consists of the package name, version, and build
-    string joined together by hyphens: *name*-*version*-*buildstring*.
-    In usage documentation, these will be referred to by `canonical_name`.
-
-.. _filename:
-.. index::
-    pair: terminology; filename
-
-**file name**
-    conda package filenames are canonical names, plus the suffix *.tar.bz2*.
-
-
-These components are illustrated in the following figure:
-
-.. figure::  images/conda_names.png
-   :align:   center
-
-   Different parts of conda package names.
-
-.. _package_spec:
-.. index::
-    pair: terminology; package specification
-    seealso: package spec; package specification
-
-Additionally, a `package specification` is a package name, together with a package version (which may be partial or absent), joined by "=". Here are some examples:
-
-* *python=2.7.3*
-* *python=2.7*
-* *python*
-
-In usage documentation, these will be referred to by `package_spec`.
-
-.. _meta_package:
-
-
-Meta-Packages
--------------
-
-conda also provides the notion of `meta-packages`.  A meta-package is a conda
-package that only has dependencies, no files. An easy way to make a
-meta-package is with the ``conda metapackage`` command.
 
 .. _directory_structure:
 
-
-Directory Structure
--------------------
+Conda system
+------------
 
 The conda system has the following directory structure:
 
 **ROOT_DIR**
-    The directory that Anaconda (or Miniconda) was installed
-    into; for example, */opt/Anaconda* or *C:\\Anaconda*
+    The directory that Miniconda was installed into; for example,
+    */opt/miniconda* or *C:\\Program Files\\Miniconda*
 
     */pkgs*
         Also referred to as *PKGS_DIR*. This directory contains exploded
@@ -218,16 +138,18 @@ The conda system has the following directory structure:
     |   */include*
     |   */lib*
     |   */share*
-    |       These subdirectories comprise the default Anaconda environment.
+    |       These subdirectories comprise the default/root conda environment.
 
 Other conda environments usually contain the same subdirectories as the
-default environment.
+default/root environment.
 
+.. This section should be moved elsewhere, it's too much of a tutorial for
+   the introduction section.
 
 Creating Python 3.4 or Python 2.6 environments
 ----------------------------------------------
 
-Anaconda supports Python 2.6, 2.7, 3.3, and 3.4.  The default is Python 2.7 or
+Conda supports Python 2.6, 2.7, 3.3, and 3.4.  The default is Python 2.7 or
 3.4, depending on which installer you used.
 
 To get started, you need to create an environment using the :ref:`conda create <create_example>`
@@ -280,7 +202,3 @@ its previous state, use:
     $ source deactivate
 
 On Windows, this is just ``deactivate``.
-
-
-
-.. _YAML syntax: http://en.wikipedia.org/wiki/YAML

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -2,14 +2,17 @@
 Introduction
 ============
 
-The `conda` command is the primary interface for managing installations
-of various packages.  It can query and search the package index and current
-installation, create new environments, and install and update packages
-into existing conda environments.
+Conda is a cross-platform, Python-agnostic binary package manager. Conda can:
 
-------------------
+- `Search <commands/conda-search.html>`_ for packages in a repository/package
+  index/channel or a current installation.
+- `Create <commands/conda-create.html>`_ conda environments.
+- `Install <commands/conda-install>`_ and `update <conda-update.html>`_
+  packages into new and existing environments.
+
+
 Conda Overview
-------------------
+--------------
 
 .. _package:
 .. index::
@@ -19,12 +22,18 @@ Conda Overview
 .. index::
     pair: terminology; environment
 
-conda is an application for finding and installing software packages.
-A conda `package` is a binary tarball containing system-level libraries,
-Python modules, executable programs, or other components.
-conda keeps track of dependencies between packages and platform
-specifics, making it simple to create working environments from different
-sets of packages.
+
+Packages
+~~~~~~~~
+
+A conda `package` is a binary archive (tarball) containing system-level
+libraries, Python modules, executable programs, or other components. Conda
+keeps track of dependencies between packages and platform specifics, making it
+simple to install sets of packages.
+
+
+Environments
+~~~~~~~~~~~~
 
 A `conda environment` is a filesystem directory that contains a specific
 collection of conda packages.  As a concrete example, you might want to
@@ -32,6 +41,15 @@ have one environment that provides NumPy 1.7, and another environment that
 provides NumPy 1.6 for legacy testing.  conda makes this kind of mixing
 and matching easy.  To begin using an environment, simply set
 your **PATH** variable to point to its `bin` directory.
+
+Since conda environments are simply directories, they may be created anywhere.
+However, conda has a notion of `locations` which are also simply directories
+that are known to conda, and contain environments within. Conda environments
+created in such locations are said to be "known", and can be displayed for
+easy reference. Conda has a default system location, but additional locations
+may be specified (see `Directory Structure`_ and :ref:`config`, respectively,
+for more details).
+
 
 .. _channel:
 .. index::
@@ -50,22 +68,34 @@ your **PATH** variable to point to its `bin` directory.
     pair: terminology; deactivated
 
 
-Conda packages are downloaded from remote ``channels``, which are simply URLs
-to directories containing conda packages.
-The conda command starts with a default set of channels to search, but users may exert control over this list; for example, if they wish to maintain a private or internal channel (see :ref:`config` for details).
+Channels
+~~~~~~~~
+
+Conda packages can be installed from local or remote ``channels`` within
+repositories. A channel is a simple URL to a folder containing conda packages.
+
+Conda comes with a default set of channels to search and install packages
+from. However, these can be changed easily, additional default channels can
+be configured or a specific channel can be specified *ad hoc* when installing a
+package (see :ref:`config` for details).
+
+Channels can be private, public, based on a single machine or local network or
+hosted online.
 
 Continuum provides the following standard channels:
- * ``http://repo.continuum.io/pkgs/dev`` - Experimental or developmental versions of packages
+
+ * ``http://repo.continuum.io/pkgs/dev`` - Experimental or developmental
+   versions of packages
  * ``http://repo.continuum.io/pkgs/gpl`` - GPL licensed packages
  * ``http://repo.continuum.io/pkgs/free`` - non GPL open source packages
 
-To view all available packages, you can use ``conda search``.  See the :ref:`search command examples <search_example>` for more information.
+To view all available packages, you can use ``conda search``.  See the
+:ref:`search command examples <search_example>` for more information.
 
-Once a conda package has been downloaded, it is said to
-be `locally available`.
+Once a conda package has been downloaded, it is said to be "locally available".
 A locally available package that has been linked into an conda environment
-is said to be `linked`.
-Conversely, unlinking a package from an environment causes it to be `unlinked`.
+is said to be "linked". Conversely, unlinking a package from an environment
+causes it to be "unlinked".
 
 
 .. _location:
@@ -76,16 +106,7 @@ Conversely, unlinking a package from an environment causes it to be `unlinked`.
 .. index::
     pair: terminology; known
 
-Since conda environments are simply directories, they may be created
-anywhere.  However, conda has a notion of `locations` which are also
-simply directories that are known to conda, and contain environments
-within.  Conda environments created in such locations are said to
-be `known`, and can be displayed for easy reference.  Conda has a default
-system location, but additional locations may be specified (see `Directory
-Structure`_ and :ref:`config`, respectively, for more details).
 
-
---------------------------
 Package Naming Conventions
 --------------------------
 
@@ -165,7 +186,6 @@ In usage documentation, these will be referred to by `package_spec`.
 .. _meta_package:
 
 
--------------
 Meta-Packages
 -------------
 
@@ -176,7 +196,6 @@ meta-package is with the ``conda metapackage`` command.
 .. _directory_structure:
 
 
--------------------
 Directory Structure
 -------------------
 
@@ -204,7 +223,7 @@ The conda system has the following directory structure:
 Other conda environments usually contain the same subdirectories as the
 default environment.
 
-----------------------------------------------
+
 Creating Python 3.4 or Python 2.6 environments
 ----------------------------------------------
 
@@ -262,22 +281,6 @@ its previous state, use:
 
 On Windows, this is just ``deactivate``.
 
----------------------------------
-Update Anaconda to latest version
----------------------------------
-
-To update to the latest version of Anaconda, it is best to first
-ensure you have the latest version of conda:
-
-.. code-block:: bash
-
-    $ conda update conda
-
-    # Now you are ready to update Anaconda
-
-    $ conda update anaconda
-
-Look here for additional :ref:`update examples <update_example>`.
 
 
 .. _YAML syntax: http://en.wikipedia.org/wiki/YAML

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -40,12 +40,12 @@ A typical package file name could be something like:
 
 .. _meta_package:
 
-Meta-Packages
--------------
+Metapackages
+------------
 
-conda also provides the notion of `meta-packages`.  A meta-package is a conda
+conda also provides the notion of `metapackages`.  A metapackage is a conda
 package that only has dependencies, no files. An easy way to make a
-meta-package is with the ``conda metapackage`` command.
+metapackage is with the ``conda metapackage`` command.
 
 
 .. _environment:
@@ -177,9 +177,9 @@ command.
     $ conda create -n py34 python=3.4 anaconda
 
 Here, 'py34' is the name of the environment to create, and 'anaconda' is the
-meta-package that includes all of the actual Python packages comprising
+metapackage that includes all of the actual Python packages comprising
 the Anaconda distribution.  When creating a new environment and installing
-the Anaconda meta-package, the NumPy and Python versions can be specified,
+the Anaconda metapackage, the NumPy and Python versions can be specified,
 e.g. `numpy=1.7` or `python=3.4`.
 
 .. code-block:: bash

--- a/docs/source/package-name.rst
+++ b/docs/source/package-name.rst
@@ -1,0 +1,82 @@
+==========================
+Package Naming Conventions
+==========================
+
+Names and versions of software packages do not follow any prescribed rules.
+However, in order to facilitate communication and documentation, conda employs
+the following naming conventions with respect to packages:
+
+.. _package_name:
+.. index::
+    pair: terminology; package name
+    seealso: name; package name
+
+**package name**
+    The name of a package, without any reference to a particular version.
+    Conda package names are normalized, and may contain only lowercase alpha
+    characters, numeric digits, underscores, or hyphens.  In usage
+    documentation, these will be referred to by `package_name`.
+
+.. _package_version:
+.. index::
+    pair: terminology; package version
+    seealso: name; package version
+
+**package version**
+    A version number or string, often similar to *X.Y* or *X.Y.Z*, but may
+    take other forms as well.
+
+.. _build_string:
+.. index::
+    pair: terminology; build string
+    seealso: name; build string
+
+**build string**
+    An arbitrary string that identifies a particular build of a package for
+    conda.  It may contain suggestive mnemonics but these are subject to
+    change and should not be relied upon or attempted to be parsed for any
+    specific information.
+
+.. _canonical_name:
+.. index::
+    pair: terminology; canonical name
+    seealso: name; canonical name
+
+**canonical name**
+    The canonical name consists of the package name, version, and build
+    string joined together by hyphens: *name*-*version*-*buildstring*.
+    In usage documentation, these will be referred to by `canonical_name`.
+
+.. _filename:
+.. index::
+    pair: terminology; filename
+
+**file name**
+    conda package filenames are canonical names, plus the suffix *.tar.bz2*.
+
+
+These components are illustrated in the following figure:
+
+.. figure::  images/conda_names.png
+   :align:   center
+
+   Different parts of conda package names.
+
+.. _package_spec:
+.. index::
+    pair: terminology; package specification
+    seealso: package spec; package specification
+
+
+Package specification
+---------------------
+
+Additionally, a `package specification` is a package name, together with a
+package version (which may be partial or absent), joined by "=". Here are some
+examples:
+
+* *python=2.7.3*
+* *python=2.7*
+* *python*
+
+In usage documentation, these will be referred to by `package_spec`.

--- a/docs/source/pip-comparison.rst
+++ b/docs/source/pip-comparison.rst
@@ -1,0 +1,26 @@
+===================
+Conda for pip users
+===================
+
+If you've used `pip` and `virtualenv` in the past, you can use conda to perform
+the operations you are used to as shown in the table below.
+
+========================= =============================================== ===============================================
+Operation                 pip command                                     conda command
+========================= =============================================== ===============================================
+Install a package         ``pip install $PACKAGE_NAME``                   ``conda install $PACKAGE_NAME``
+Install from location     ``pip install --index-url $URL $PACKAGE_NAME``  ``conda install --channel $URL $PACKAGE_NAME``
+Update a package          ``pip install --upgrade $PACKAGE_NAME``         ``conda update --name $PACKAGE_NAME``
+Uninstall a package       ``pip uninstall $PACKAGE_NAME``                 ``conda remove --name $ENV_NAME $PACKAGE_NAME``
+Create an environment     ``cd $ENV_BASE_DIR; virtualenv $ENV_NAME``      ``conda create --name $ENV_NAME python``
+Activate an environment   ``source $ENV_BASE_DIR/$ENV_NAME/bin/activate`` ``source activate $ENV_NAME``
+Deactivate an environment ``deactivate``                                  ``source deactivate``
+Search available packages ``pip search $SEARCH_TERM``                     ``conda search $SEARCH_TERM``
+List installed packages   ``pip list``                                    ``conda list --name $ENV_NAME``
+Create requirements file  ``pip freeze``                                  ``conda list --export``
+========================= =============================================== ===============================================
+
+.. Show what files a package has installed ``pip show --files $PACKAGE_NAME``  not possible
+.. Print details on an individual package ``pip show $PACKAGE_NAME``  not possible
+.. List available environments   not possible   ``conda info -e``
+.. #user will want to pass that through ``tail -n +3 | awk '{print $1;}'``

--- a/docs/source/pip-comparison.rst
+++ b/docs/source/pip-comparison.rst
@@ -1,5 +1,5 @@
 ===================
-Conda for pip users
+Conda for pip Users
 ===================
 
 If you've used `pip` and `virtualenv` in the past, you can use conda to perform

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -1,5 +1,5 @@
 =================
-Quick-start guide
+Quick-Start Guide
 =================
 
 

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -1,0 +1,49 @@
+=================
+Quick-start guide
+=================
+
+
+To demonstrate the ease of a typical conda workflow, we will create a conda environment
+with a version of `NumPy <http://www.numpy.org>`_ different from the default version.
+
+First, we will check our system's Numpy version:
+
+.. code-block:: bash
+
+    $ python
+    Python 2.7.5 |Anaconda 1.6.1 (x86_64)| (default, Jun 28 2013, 22:20:13)
+    [GCC 4.0.1 (Apple Inc. build 5493)] on darwin
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> import numpy
+    >>> numpy.__version__
+    '1.7.1'
+
+Next we will create a conda environment using a different version of NumPy:
+
+.. code-block:: none
+
+    $ conda create -p ~/anaconda/envs/test numpy=1.6 anaconda
+
+    Package plan for creating environment at /Users/maggie/anaconda/envs/test:
+
+    The following packages will be downloaded:
+
+    [      COMPLETE      ] |#################################################| 100%
+
+Now we change our **PATH** variable to point to the new environment:
+
+.. code-block:: bash
+
+    $ export PATH=~/anaconda/envs/test/bin/:$PATH
+
+Finally, we check the version of Numpy again:
+
+.. code-block:: python
+
+    $ python
+    Python 2.7.5 |Anaconda 1.6.1 (x86_64)| (unknown, Jan 10 2013, 12:19:03)
+    [GCC 4.0.1 (Apple Inc. build 5493)] on darwin
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> import numpy
+    >>> numpy.__version__
+    '1.6.2'

--- a/docs/source/spec.rst
+++ b/docs/source/spec.rst
@@ -1,4 +1,4 @@
-Conda package specification
+Conda Package Specification
 ===========================
 
 A conda package is a bzipped tar archive (``.tar.bz2``) which contains

--- a/docs/source/tab-completion.rst
+++ b/docs/source/tab-completion.rst
@@ -1,5 +1,5 @@
 ==============
-Tab completion
+Tab Completion
 ==============
 
 ``conda`` supports tab completion in bash shells via the ``argcomplete``

--- a/docs/source/tab-completion.rst
+++ b/docs/source/tab-completion.rst
@@ -1,0 +1,29 @@
+==============
+Tab completion
+==============
+
+``conda`` supports tab completion in bash shells via the ``argcomplete``
+package. First, make sure that ``argcomplete`` is installed
+
+.. code-block:: bash
+
+   $ conda install argcomplete
+
+Then add
+
+.. code-block:: bash
+
+   eval "$(register-python-argcomplete conda)"
+
+to your bash profile. You can test that it works by opening a new terminal
+window and typing
+
+.. code-block:: bash
+
+   $ conda ins<TAB>
+
+It should complete to
+
+.. code-block:: bash
+
+   $ conda install


### PR DESCRIPTION
I've restructured and tidied the docs a little bit. The main thing is that I have seperated the packager manager versus package builder docs as much as possible. The intro is also a bit less techy with a focus on explain the ecosystem with references to the examples/tutorials and command reference.

I can probably still tidy this further, add some cross-references, etc. 

Let me know what you think.