### PR TITLE
Patch 2

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,30 +2,70 @@
 Installation
 ============
 
-Conda is part of the Anaconda Python distribution which can be downloaded from `here
-<https://store.continuum.io/cshop/anaconda/>`_.
+Conda is a cross-platform package manager and environment manager program that installs, 
+runs, and updates packages and their dependencies, so you can easily set up and switch 
+between environments on your local computer.  Conda is included in all versions of 
+Anaconda, Anaconda Server, and Miniconda. 
 
-Conda can also be installed as a stand-alone packages known as
-*Miniconda*. Installers for Linux, OS X and Windows are
-available on `the Conda site <http://conda.pydata.org/miniconda.html#miniconda>`_.
+The easiest way to get and install conda is to download Anaconda, the full version 
+of Anaconda that includes Python and 150+ open source packages that install at the 
+same time. It takes about ten minutes for all the packages to install. 
 
+These installation instructions are for a full install of Anaconda for Windows, Macintosh,
+or Linux. 
 
-Silent installation
+NOTE: If you prefer to quickly install the minimal Miniconda package, simply download 
+it from the `Miniconda downloads page <http://conda.pydata.org/miniconda.html#miniconda>`_
+and follow the rest of the instructions below.
+
+Windows Anaconda installation
 -------------------
 
-Silent installation of Miniconda can be used for deployment or testing or building services such as Travis CI and
-Appveyor.
+In your browser, download the Anaconda installer for Windows from the `Anaconda downloads 
+page <https://store.continuum.io/cshop/anaconda/>`_ then double click the .exe file and follow 
+the instructions on the screen.  If unsure about any setting, simply accept the defaults as 
+they all can be changed later.
 
-The lastest version of the Miniconda installer can be found `in the repo <http://repo.continuum.io/miniconda/>`_. In any
-case, an out of date installation can be updated with a simple:
+NOTE: When finished, a new terminal window will open. If not, close the terminal
+window, then click Start - Run - Command Prompt. The install will not take effect 
+until AFTER you close and re-open your terminal window.
+
+Macintosh Anaconda installation
+-------------------
+
+In your browser, download the Anaconda installer for Macintosh from the `Anaconda downloads 
+page <https://store.continuum.io/cshop/anaconda/>`_  then double click 
+the .pkg file and follow the instructions on the screen. If unsure about any setting, 
+simply accept the defaults as they all can be changed later.
+
+NOTE: The install will not take effect until AFTER you close and reopen your terminal 
+window.
+
+Linux Anaconda installation
+-------------------
+
+In your browser, download the Anaconda installer for Linux from the `Anaconda downloads 
+page <https://store.continuum.io/cshop/anaconda/>`_ then in your terminal 
+window type the following and follow the prompts on the installer screens. If unsure 
+about any setting, simply accept the defaults as they all can be changed later:
 
 .. code-block:: console
 
-    conda update conda
+    bash Anaconda-latest-Linux-x86_64.sh
+
+NOTE: The install will not take effect until AFTER you close and reopen your terminal 
+window.
 
 
-Windows
+Optional silent installation
 ~~~~~~~
+
+Silent mode turns off screen prompts and accepts the system defaults. Silent installation of Miniconda may be used for deployment or testing or building services such as Travis CI and
+Appveyor. 
+
+
+Windows silent installation
+-------------------
 
 The Windows installer of Miniconda can be run in silent mode using the ``/S`` argument. The following optional arguments
 are supported:
@@ -47,8 +87,8 @@ The following command installs Miniconda for all users without registering Pytho
         /S /D=C:\Program Files\Miniconda3
 
 
-Linux and OS X
-~~~~~~~~~~~~~~
+Linux and OS X silent installation
+-------------------
 
 Silent installation of Miniconda for Linux and OS X is a simple as specifying the ``-b`` and ``-p`` arguments of the
 bash installer. The following arguments are supported:
@@ -57,7 +97,7 @@ bash installer. The following arguments are supported:
 - ``-p``, installation prefix/path
 - ``-f``, force installation even if prefix ``-p`` already exists
 
-Batch mode assumes that you agree to the license agreement, and it does not
+NOTE: Batch mode assumes that you agree to the license agreement, and it does not
 edit the .bashrc or .bash_profile files.
 
 A complete example:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -19,7 +19,7 @@ it from the `Miniconda downloads page <http://conda.pydata.org/miniconda.html#mi
 and follow the rest of the instructions below.
 
 Windows Anaconda installation
--------------------
+~~~~~~~
 
 In your browser, download the Anaconda installer for Windows from the `Anaconda downloads 
 page <https://store.continuum.io/cshop/anaconda/>`_ then double click the .exe file and follow 
@@ -31,7 +31,7 @@ window, then click Start - Run - Command Prompt. The install will not take effec
 until AFTER you close and re-open your terminal window.
 
 Macintosh Anaconda installation
--------------------
+~~~~~~~
 
 In your browser, download the Anaconda installer for Macintosh from the `Anaconda downloads 
 page <https://store.continuum.io/cshop/anaconda/>`_  then double click 
@@ -42,7 +42,7 @@ NOTE: The install will not take effect until AFTER you close and reopen your ter
 window.
 
 Linux Anaconda installation
--------------------
+~~~~~~~
 
 In your browser, download the Anaconda installer for Linux from the `Anaconda downloads 
 page <https://store.continuum.io/cshop/anaconda/>`_ then in your terminal 
@@ -65,7 +65,7 @@ Appveyor.
 
 
 Windows silent installation
--------------------
+~~~~~~~
 
 The Windows installer of Miniconda can be run in silent mode using the ``/S`` argument. The following optional arguments
 are supported:
@@ -88,7 +88,7 @@ The following command installs Miniconda for all users without registering Pytho
 
 
 Linux and OS X silent installation
--------------------
+~~~~~~~
 
 Silent installation of Miniconda for Linux and OS X is a simple as specifying the ``-b`` and ``-p`` arguments of the
 bash installer. The following arguments are supported:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -19,7 +19,7 @@ it from the `Miniconda downloads page <http://conda.pydata.org/miniconda.html#mi
 and follow the rest of the instructions below.
 
 Windows Anaconda installation
-~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In your browser, download the Anaconda installer for Windows from the `Anaconda downloads 
 page <https://store.continuum.io/cshop/anaconda/>`_ then double click the .exe file and follow 
@@ -31,7 +31,7 @@ window, then click Start - Run - Command Prompt. The install will not take effec
 until AFTER you close and re-open your terminal window.
 
 Macintosh Anaconda installation
-~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In your browser, download the Anaconda installer for Macintosh from the `Anaconda downloads 
 page <https://store.continuum.io/cshop/anaconda/>`_  then double click 
@@ -42,7 +42,7 @@ NOTE: The install will not take effect until AFTER you close and reopen your ter
 window.
 
 Linux Anaconda installation
-~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In your browser, download the Anaconda installer for Linux from the `Anaconda downloads 
 page <https://store.continuum.io/cshop/anaconda/>`_ then in your terminal 
@@ -56,16 +56,17 @@ about any setting, simply accept the defaults as they all can be changed later:
 NOTE: The install will not take effect until AFTER you close and reopen your terminal 
 window.
 
-
+============================
 Optional silent installation
-~~~~~~~
+============================
+
 
 Silent mode turns off screen prompts and accepts the system defaults. Silent installation of Miniconda may be used for deployment or testing or building services such as Travis CI and
 Appveyor. 
 
 
 Windows silent installation
-~~~~~~~
+---------------------------
 
 The Windows installer of Miniconda can be run in silent mode using the ``/S`` argument. The following optional arguments
 are supported:
@@ -88,7 +89,7 @@ The following command installs Miniconda for all users without registering Pytho
 
 
 Linux and OS X silent installation
-~~~~~~~
+----------------------------------
 
 Silent installation of Miniconda for Linux and OS X is a simple as specifying the ``-b`` and ``-p`` arguments of the
 bash installer. The following arguments are supported:


### PR DESCRIPTION
Added Anaconda installation instructions for Windows, Mac and Linux, moved the "Silent installation" section down to the bottom, cleaned up formatting and made it conform more to the documentation standards guide.