### PR TITLE
Rewrite help section.

### DIFF
--- a/docs/source/conda-pip-translator.rst
+++ b/docs/source/conda-pip-translator.rst
@@ -1,0 +1,25 @@
+====================
+Conda/PIP translator
+====================
+
+If you've used pip and virtualenv in the past, you can use conda to perform the operations you are used to.
+
+=====================================   =======================================================   ===========================================================
+Operation                               Pip Command                                               Conda Command
+=====================================   =======================================================   ===========================================================
+Install a package                       ``pip install $PACKAGE_NAME``                             ``conda install $PACKAGE_NAME``
+Uninstall a package                     ``pip uninstall $PACKAGE_NAME``                           ``conda remove --name $ENVIRONMENT_NAME $PACKAGE_NAME``
+Create an environment                   ``cd $ENV_BASE_DIR; virtualenv $ENVIRONMENT_NAME``        ``conda create --name $ENVIRONMENT_NAME python``
+Activate an environment                 ``source $ENV_BASE_DIR/$ENVIRONMENT_NAME/bin/activate``   ``source activate $ENVIRONMENT_NAME``
+Deactivate an environment               ``deactivate``                                            ``source deactivate``
+Search available packages               ``pip search $SEARCH_TERM``                               ``conda search $SEARCH_TERM``
+Install package from specific source    ``pip install --index-url $URL $PACKAGE_NAME``            ``conda install --channel $URL $PACKAGE_NAME``
+List installed packages                 ``pip list``                                              ``conda list --name $ENVIRONMENT_NAME``
+Create requirements file                ``pip freeze``                                            ``conda list --export``
+Update a package                        ``pip install --upgrade $PACKAGE_NAME``                   ``conda update --name $PACKAGE_NAME``
+=====================================   =======================================================   ===========================================================
+
+.. Show what files a package has installed ``pip show --files $PACKAGE_NAME``  not possible
+.. Print details on an individual package ``pip show $PACKAGE_NAME``  not possible
+.. List available environments   not possible   ``conda info -e``
+.. #user will want to pass that through ``tail -n +3 | awk '{print $1;}'``

--- a/docs/source/get-more-help.rst
+++ b/docs/source/get-more-help.rst
@@ -1,0 +1,11 @@
+=============
+Get more help
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   faq
+   troubleshooting
+   conda-pip-translator
+   examples

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -92,9 +92,7 @@ User Guide
    quick-install
    installation
    test-drive
-   examples
-   faq
-   troubleshooting
+   get-more-help
    glossary
    config
    build


### PR DESCRIPTION
We rewrote the help section as file get-more-help with the existing
'FAQ', existing 'Troubleshooting', 'Conda/PIP Translator' from the
'Conda-PIP Rosetta Stone' section we removed from 'Command Reference',
and the existing 'Examples'.