### PR TITLE
Reorder the sidebar for 'using conda'

### DIFF
--- a/docs/source/using/index.rst
+++ b/docs/source/using/index.rst
@@ -4,8 +4,8 @@ Using conda
 .. toctree::
 
    using
-   cheatsheet
-   test-drive
    envs
    py
    pkgs
+   test-drive
+   cheatsheet


### PR DESCRIPTION
Reorder the sidebar to end with the test drive and cheat sheet, after
the files that refer to one another as being in order.