### PR TITLE
Use "OS X" not "OSX"

### DIFF
--- a/docs/source/build_tutorials/pkgs.rst
+++ b/docs/source/build_tutorials/pkgs.rst
@@ -18,7 +18,7 @@ Building a simple conda package can be done in two steps, with two optional step
 
 #. Before you start: make sure you have all the requirements.
 #. Build a simple package with conda skeleton and PyPI: generate a simple package.
-#. Optional - Convert conda package for other platforms: convert your simple package so it can be used on on Linux, Mac and Windows.
+#. Optional - Convert conda package for other platforms: convert your simple package so it can be used on on Linux, OS X and Windows.
 #. Optional - Upload package to Anaconda.org: upload to a public or private repository so others can share your package.
 
 
@@ -76,7 +76,7 @@ commands, but for pyinstrument, any changes are optional.
 
 What are these three files?
     **meta.yaml:** Contains all the metadata in the recipe. Only package/name and package/version are required; everything else is optional.
-    **build.sh:** Environment and other variables for Unix and Mac - whether 32 or 64-bit, path info, etc.
+    **build.sh:** Environment and other variables for Linux and OS X - whether 32 or 64-bit, path info, etc.
     **bld.bat:** The same environment and other variables for Windows.
 
 Now that you have the skeleton ready, you can use the conda build tool. Let’s try it:
@@ -93,7 +93,7 @@ Linux example file path:
 
     /home/jsmith/miniconda/conda-bld/linux-64/pyinstrument-0.13.1-py27_0.tar.bz2
 
-Macintosh example file path: 
+OS X example file path: 
 
 .. code-block:: bash
 
@@ -125,7 +125,7 @@ Now verify that Pyinstrument installed successfully:
 
 Now that you have built a package for your current platform with conda build, you can convert it for use on other platforms with the conda convert command and a platform specifier from the list {osx-64,linux-32,linux-64,win-32,win-64,all}. In the output directory, one folder will be created for each of the one or more platforms you chose, and each folder will contain a .tar.bz2 package file for that platform.
 
-Linux and Macintosh users:
+Linux and OS X users:
 
 .. code-block:: bash
 
@@ -174,6 +174,3 @@ This completes the tutorial Intro to building conda packages using conda skeleto
 
 Please see our next tutorial, Building conda packages part 2, to learn more about the files that 
 go into each conda build and how to edit them manually. 
-
-
-

--- a/docs/source/build_tutorials/pkgs2.rst
+++ b/docs/source/build_tutorials/pkgs2.rst
@@ -238,14 +238,14 @@ Write the build script files build.sh and bld.bat
 
 The other two files you need for a build  are
 
-* **build.sh** shell script for Unix and Mac, and
+* **build.sh** shell script for Linux and OS X, and
 * **bld.bat** batch file for Windows.
 
 These two build files contain all the variables such as for 32-bit or 64-bit architecture (the ARCH
 variable) and the build environment prefix (PREFIX). The two files ``build.sh`` and ``bld.bat`` files must be
 in the same directory as your ``meta.yaml`` file.
 
-First, we'll write the build file for Linux and Macintosh, then the next file for Windows.
+First, we'll write the build file for Linux and OS X, then the next file for Windows.
 All users, in your favorite text editor, create a new file named ``build.sh`` and enter the text exactly as
 shown:
 

--- a/docs/source/build_tutorials/postgis.rst
+++ b/docs/source/build_tutorials/postgis.rst
@@ -24,7 +24,7 @@ Abstract Description of conda build
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We begin building a package by pointing conda to a directory with a ``build.sh``
-(for Linux and OSX, Windows uses ``bld.bat`` file) and ``meta.yaml`` file.
+(for Linux and OS X, Windows uses ``bld.bat`` file) and ``meta.yaml`` file.
 Respectively, these files specify the command line instructions to build a
 particular package from source, and information about where to download the
 source files and dependencies that the package requires. If these files are

--- a/docs/source/build_tutorials/postgis.rst
+++ b/docs/source/build_tutorials/postgis.rst
@@ -24,7 +24,7 @@ Abstract Description of conda build
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We begin building a package by pointing conda to a directory with a ``build.sh``
-(for Linux and MacOSX, Windows uses ``bld.bat`` file) and ``meta.yaml`` file.
+(for Linux and OSX, Windows uses ``bld.bat`` file) and ``meta.yaml`` file.
 Respectively, these files specify the command line instructions to build a
 particular package from source, and information about where to download the
 source files and dependencies that the package requires. If these files are
@@ -87,7 +87,7 @@ you'll encounter for packaging C source code distributions. Including
 key instruction to have conda configure and install in its custom build
 environment, rather than try to access root-level directories such as
 ``/usr``, which is the default installation path in normal circumstances in
-Linux and Mac OS X. If you want to follow more details of what conda is doing
+Linux and OS X. If you want to follow more details of what conda is doing
 to configure the environment, add to your ``build.sh`` file:
 
 .. code-block:: bash

--- a/docs/source/building/recipe.rst
+++ b/docs/source/building/recipe.rst
@@ -110,7 +110,7 @@ sections are optional except for package/name and package/version.
         - bspatch4 = bsdiff4.cli:main_bspatch4
 
       # If osx_is_app is set, entry points will use python.app instead of
-      # python in Mac OS X
+      # python in OS X
       osx_is_app: yes # (defaults to no)
 
       # See the Features section below for more information on features
@@ -408,7 +408,7 @@ defined in Windows:
   * - ``CYGWIN_PREFIX``
     - Same as ``PREFIX``, but as a unix-style path, e.g. ``/cygdrive/c/path/to/prefix``
 
-On non-Windows (Linux and Mac OS X), we have:
+On non-Windows (Linux and OS X), we have:
 
 .. list-table::
 
@@ -421,7 +421,7 @@ On non-Windows (Linux and Mac OS X), we have:
   * - ``LIBRARY_PATH``
     - ``<build prefix>/lib``
 
-On Mac OS X, we have:
+On OS X, we have:
 
 .. list-table::
 
@@ -645,7 +645,7 @@ Conda build does the following things automatically to make packages
 relocatable:
 
 - Binary object files are converted to use relative paths using
-  ``install_name_tool`` on Mac OS X and ``patchelf`` on Linux.
+  ``install_name_tool`` on OS X and ``patchelf`` on Linux.
 
 - Any text file (containing no NULL bytes) containing the build prefix or the
   placeholder prefix ``/opt/anaconda1anaconda2anaconda3`` is registered in the

--- a/docs/source/get-started/download.rst
+++ b/docs/source/get-started/download.rst
@@ -40,7 +40,7 @@ Which version of Anaconda or Miniconda should I choose?
 Should I choose GUI installer or command line installer?
 --------------------------------------------------------
 
-Whether you are on Mac, Windows or Linux, there is an installer to make it easy for you. 
+Whether you are on Linux, OS X or Windows, there is an installer to make it easy for you. 
 
 * If you do not wish to enter commands in a terminal window, choose the GUI installer. 
 * If GUIs slow you down, choose the command line version. 
@@ -74,7 +74,7 @@ Note: replace md5sum or sha1sum with the actual sum.
 
 Note: replace the path/to/filename.ext with the actual path, filename and extension. 
 
-**Mac users:**
+**OS X users:**
 
 * MD5: ``md5 path/to/filename.ext``
 * SHA1: ``sha1 path/to/filename.ext``

--- a/docs/source/help/troubleshooting.rst
+++ b/docs/source/help/troubleshooting.rst
@@ -85,8 +85,8 @@ site-specific packages can be found is in `PEP 370
 Python may try importing packages from this directory, which can cause
 issues. The recommended fix is to remove the site-specific directory.
 
-Resolution: For C libraries, unset the environment variables ``LD_LIBRARY_PATH`` on Linux and ``DYLD_LIBRARY_PATH`` on Mac OS X.
---------------------------------------------------------------------------------------------------------------------------------
+Resolution: For C libraries, unset the environment variables ``LD_LIBRARY_PATH`` on Linux and ``DYLD_LIBRARY_PATH`` on OS X.
+----------------------------------------------------------------------------------------------------------------------------
 
 These act similarly to ``PYTHONPATH`` for Python. If they are set, they can
 cause libraries to be loaded from locations other than the Conda
@@ -142,8 +142,8 @@ not a git checkout (the version should not include any hashes).
 
 .. _unknown-locale:
 
-Issue: ``ValueError unknown locale: UTF-8`` on Mac OS X
-=======================================================
+Issue: ``ValueError unknown locale: UTF-8`` on OS X
+===================================================
 
 Resolution: Uncheck "set locale environment variables on startup" setting in Terminal settings
 ----------------------------------------------------------------------------------------------
@@ -230,5 +230,3 @@ The command ``type command_name`` will always tell you exactly what is being
 run (this is better than ``which command_name``, which ignores hashed commands
 and searches the ``PATH`` directly), and ``hash -r`` (in bash) or ``rehash``
 (in zsh) will reset the hash, or you can run ``source activate``.
-
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Conda
 
 Conda is an open source package management system and environment management system for installing multiple
 versions of software packages and their dependencies and switching easily between them. It works on
-Windows, OS X, and Linux, and was created for Python programs but can package and distribute any software.
+Linux, OS X and Windows, and was created for Python programs but can package and distribute any software.
 
 Conda is included in all versions of Anaconda, Anaconda Server, and Miniconda, and is not available separately. 
 
@@ -85,4 +85,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`search`
-

--- a/docs/source/install/central.rst
+++ b/docs/source/install/central.rst
@@ -141,7 +141,7 @@ variable will overwrite this configuration file setting.
     - /opt/anaconda/envs
    
 
-* **Linux, Mac:** ``CONDA_ENVS_PATH=~/my-envs:/opt/anaconda/envs``
+* **Linux, OS X:** ``CONDA_ENVS_PATH=~/my-envs:/opt/anaconda/envs``
 * **Windows:** ``set CONDA_ENVS_PATH=C:\Users\joe\envs;C:\Anaconda\envs``
 
 
@@ -235,4 +235,3 @@ through the admin channel:
     - admin
 
 Now the user can search for packages in the allowed admin channel.
-

--- a/docs/source/install/full.rst
+++ b/docs/source/install/full.rst
@@ -11,14 +11,14 @@ Miniconda includes only conda, conda-build, and their dependencies so you can in
 These instructions are for a full install of Anaconda, which includes conda, conda-build, and 150+ 
 open source packages. 
 
-TIP: For installation instructions using our graphical installers for Mac or PC, please see 
+TIP: For installation instructions using our graphical installers for OS X or Windows, please see 
 the `Anaconda Install <http://docs.continuum.io/anaconda/install.html>`_ page. 
 
 
 Anaconda requirements
 ------------------------------------
 
-32 or 64 bit computer, 32MB available, Linux, Macintosh or Windows.
+32 or 64 bit computer, 32MB available, Linux, OS X or Windows.
 
 300 MB to download Anaconda plus another 300 to install it. 
 
@@ -51,20 +51,20 @@ Because Anaconda is contained in one directory, uninstalling Anaconda is simple 
 window, remove the entire anaconda install directory: ``rm -rf ~/anaconda``
 
 
-Macintosh Anaconda install
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+OS X Anaconda install
+~~~~~~~~~~~~~~~~~~~~~
 
 In your browser download the `Anaconda installer <http://continuum.io/downloads>`_ for 
-Macintosh, then double click the .pkg file and follow the instructions on the screen. 
+OS X, then double click the .pkg file and follow the instructions on the screen. 
 If unsure about any setting, simply accept the defaults as they all can be changed later.
 
 NOTE: The install will not take effect until AFTER you close and reopen your terminal window.
 
-**Macintosh Anaconda update**
+**OS X Anaconda update**
 
 Open a terminal window, navigate to the anaconda directory, then type ``conda update conda``
 
-**Macintosh Anaconda uninstall**
+**OS X Anaconda uninstall**
 
 Because Anaconda is contained in one directory, uninstalling Anaconda is simple -- in 
 your terminal window, remove the entire miniconda install directory: ``rm -rf ~/anaconda``

--- a/docs/source/install/quick.rst
+++ b/docs/source/install/quick.rst
@@ -25,7 +25,7 @@ replacing the word “Miniconda” with “Anaconda” in the examples below.
 Miniconda quick install requirements
 ------------------------------------
 
-32- or 64-bit computer, 32MB available, Linux, Macintosh or Windows.
+32- or 64-bit computer, 32MB available, Linux, OS X or Windows.
 
 NOTE: If you choose to install the full Anaconda package, it requires 300+ MB for 
 the download plus another 300+ to install it. 
@@ -59,10 +59,10 @@ Because Miniconda is contained in one directory, uninstalling Miniconda is simpl
 your terminal window, remove the entire miniconda install directory: ``rm -rf ~/miniconda``
 
 
-OSX Miniconda install
----------------------
+OS X Miniconda install
+----------------------
 
-In your browser download the `Miniconda installer for OSX <http://conda.pydata.org/miniconda.html>`_, then in your terminal 
+In your browser download the `Miniconda installer for OS X <http://conda.pydata.org/miniconda.html>`_, then in your terminal 
 window type the following and follow the prompts on the installer screens. If unsure about any setting, 
 simply accept the defaults as they all can be changed later.
 
@@ -77,11 +77,11 @@ correctly, you will see a list of packages that were installed.
 
 Next, go to our :doc:`30-minute conda test drive </using/test-drive>`.
 
-**OSX Miniconda update**
+**OS X Miniconda update**
 
 Open a terminal window, navigate to the anaconda directory, then type ``conda update conda``.
 
-**OSX Miniconda uninstall**
+**OS X Miniconda uninstall**
 
 Because Miniconda is contained in one directory, uninstalling Miniconda is simple -- in 
 your terminal window, remove the entire miniconda install directory: ``rm -rf ~/miniconda``

--- a/docs/source/using/envs.rst
+++ b/docs/source/using/envs.rst
@@ -38,7 +38,7 @@ TIP:  Many frequently used options after two dashes (--) can be abbreviated with
 Change environments (activate/deactivate)
 ----------------------------------------------------
 
-**Linux, Mac:** ``source activate snowflakes``
+**Linux, OS X:** ``source activate snowflakes``
 
 **Windows:**  ``activate snowflakes``
 
@@ -48,7 +48,7 @@ TIP: Environments are installed by default into the envs directory in your conda
 
 Deactivate the environment with the following:
 
-**Linux, Mac:** ``source deactivate snowflakes``
+**Linux, OS X:** ``source deactivate snowflakes``
 
 **Windows:**  ``deactivate snowflakes``
 
@@ -153,7 +153,7 @@ To enable another person to create an exact copy of your environment, you will e
 
 Activate the environment you wish to export:
 
-**Mac, Linux:** ``source activate peppermint``
+**Linux, OS X:** ``source activate peppermint``
 
 **Windows:** ``activate peppermint``
 
@@ -174,7 +174,7 @@ To create a copy of another developer’s environment from their environment.yml
 
 Deactivate your current environment:
 
-**Mac, Linux:** ``source deactivate starfish``
+**Linux, OS X:** ``source deactivate starfish``
 
 **Windows:** ``deactivate starfish``
 
@@ -198,7 +198,7 @@ In the same directory as the environment.yml file, create the new environment:
 
 Activate the new environment:
 
-**Mac, Linux:** ``source activate peppermint``
+**Linux, OS X:** ``source activate peppermint``
 
 **Windows:** ``activate peppermint``
 
@@ -211,5 +211,3 @@ Verify that the new environment was installed correctly:
    conda list
 
 Next, we'll take a look at managing Python.
-
-

--- a/docs/source/using/py.rst
+++ b/docs/source/using/py.rst
@@ -22,7 +22,7 @@ So now let’s say you need Python 3 to learn programming, but you don’t want 
 
    conda create --name snakes python=3   
 
-**Linux, Mac:** ``source activate snakes``
+**Linux, OS X:** ``source activate snakes``
 
 **Windows:**  ``activate snakes``
 
@@ -47,7 +47,7 @@ Use a different version of Python
 
 To switch to the new environment with a different version of Python, you simply need to activate it. Let’s switch back to the default, 2.7: 
 
-**Linux, Mac:** ``source activate snowflakes``
+**Linux, OS X:** ``source activate snowflakes``
 
 **Windows:**  ``activate snowflakes``
 

--- a/docs/source/using/test-drive.rst
+++ b/docs/source/using/test-drive.rst
@@ -33,7 +33,7 @@ you are currently using. With just a few commands you can set up a totally separ
 different version of Python, and yet continue to run your usual version of Python in your normal environment.
 That’s the power of having an environment manager like conda.
 
-TIP: Whether you are using Linux, Mac or the Windows command prompt, in your terminal window the conda commands
+TIP: Whether you are using Linux, OS X or the Windows command prompt, in your terminal window the conda commands
 are all the same unless noted.
 
 **Verify that conda is installed**
@@ -93,7 +93,7 @@ first letter. So ``--name`` and ``-n`` options are the same and ``--envs`` and `
 
 **Activate the new environment:**
 
-* Linux, Mac: ``source activate snowflakes``
+* Linux, OS X: ``source activate snowflakes``
 * Windows:  ``activate snowflakes``
 
 TIP: Environments are installed by default into the envs directory in your conda directory. You can specify a
@@ -155,12 +155,12 @@ of your prompt:
 
 To change to another environment, type the following with the name of the environment:
 
-* Linux, Mac: ``source activate bunnies``
+* Linux, OS X: ``source activate bunnies``
 * Windows:  ``activate bunnies``
 
 To change your path from the current environment back to the root:
 
-* Linux, Mac: `source deactivate`
+* Linux, OS X: `source deactivate`
 * Windows:  `deactivate`
 
 TIP: When the environment is deactivated, ``(bunnies)`` will no longer be shown in the prompt.
@@ -231,7 +231,7 @@ the latest version of Python 3 as follows:
 
    conda create --name snakes python=3
 
-* Linux, Mac: ``source activate snakes``
+* Linux, OS X: ``source activate snakes``
 * Windows:  ``activate snakes``
 
 TIP: It would be wise to name this environment a descriptive name like ``python3`` but that is not as much fun.
@@ -260,7 +260,7 @@ Verify that the snakes environment uses python version 3:
 To switch to the new environment with a different version of Python, you simply need to activate it.
 Let’s switch back to the default, 2.7:
 
-* Linux, Mac: ``source activate snowflakes``
+* Linux, OS X: ``source activate snowflakes``
 * Windows:  ``activate snowflakes``
 
 **Verify Python version in environment**
@@ -276,7 +276,7 @@ Verify that the snowflakes environment uses python version 2:
 After you are finished working in the snowflakes environment, deactivate this environment and
 revert your PATH to its previous state:
 
-* Linux, Macintosh: ``source deactivate``
+* Linux, OS X: ``source deactivate``
 * Windows: ``deactivate``
 
 .. _managing-pkgs:
@@ -327,7 +327,7 @@ the current environment.
 
 Now activate the bunnies environment , and do a conda list to see the new program installed:
 
-* Linux, Mac: ``source activate bunnies``
+* Linux, OS X: ``source activate bunnies``
 * Windows:  ``activate bunnies``
 
 All platforms:
@@ -378,7 +378,7 @@ Pip install packages
 
 We activate the environment where we want to put the program, then pip install a program named “See”:
 
-* Linux, Mac: source activate bunnies
+* Linux, OS X: source activate bunnies
 * Windows:  activate bunnies
 
 All platforms:
@@ -453,7 +453,7 @@ Snakes is no longer shown in the environment list, so we know it was deleted.
 
 **Remove conda**
 
-* Linux, Mac:
+* Linux, OS X:
 
 Remove the Anaconda OR Miniconda install directory:
 

--- a/docs/source/using/using.rst
+++ b/docs/source/using/using.rst
@@ -24,7 +24,7 @@ The same help that is available in conda is also available online from our  :doc
 Managing conda
 ~~~~~~~~~~~~~~~
 
-NOTE: Whether you are using Linux, Mac or the Windows command prompt, in your terminal window the conda commands are all the same unless noted.
+NOTE: Whether you are using Linux, OS X or the Windows command prompt, in your terminal window the conda commands are all the same unless noted.
 
 Verify that conda is installed, check current conda version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Per Aaron & Apple site; Continuum style guide is also fixed.