### PR TITLE
Warn users about passwords in recipe files

### DIFF
--- a/docs/source/building/recipe.rst
+++ b/docs/source/building/recipe.rst
@@ -62,5 +62,10 @@ Conda-build invokes the following steps in this order:
 There are example recipes for many conda packages in the `conda-recipes
 <https://github.com/continuumio/conda-recipes>`_ repo.
 
+NOTE: All recipe files, including meta.yaml and build scripts, are included in 
+the final package archive which is distributed to users, so be careful not to 
+put passwords or other sensitive information into recipes where it could leak to 
+the public.
+
 The :ref:`conda skeleton <skeleton_ref>` command can help to make skeleton
 recipes for common repositories, such as `PyPI <https://pypi.python.org/pypi>`_.


### PR DESCRIPTION
Per https://github.com/conda/conda-build/issues/427#issuecomment-107726272 ,
warn users that meta.yaml, build scripts, and so on are included in the final
package archive distributed to the public, so they should not include
sensitive information such as passwords.