### PR TITLE
Note 2048 bit RSA key size

### DIFF
--- a/docs/source/signed-packages.rst
+++ b/docs/source/signed-packages.rst
@@ -4,7 +4,7 @@ Signing conda packages
 
 **PREVIEW RELEASE**
 
-Conda build has the ability to verify 1024 bit RSA signatures of conda packages. Conda-build includes a tool that allows signing those conda packages and adding the required package metadata to the conda repository index.
+Conda has the ability to verify RSA signatures on conda packages, and conda-build can generate key pairs, sign conda packages, and add the required package metadata to the conda repository index. Any key size is supported, and the default is 2048 bits.
 
 Given any public/private key pair, you may sign any file using the private key, and the other person who receives the file must verify the signature against the public key in order to use the file. The person verifying the signature is assured that the signature was indeed created using the private key.
 
@@ -83,5 +83,3 @@ When the client tries to install the signed package using the `conda` command, c
 
 - Conda will permit the installation if it finds the signature. 
 - Conda will exit if (i) the signature is invalid (ii) the signature is not found or, (iii) the public key is not installed.
-
-


### PR DESCRIPTION
Note the change to a default RSA key size of 2048 bits.