### PR TITLE
Add a redirect to the redirect page index to make "next" and "prev" work

### DIFF
--- a/docs/source/help/faq.rst
+++ b/docs/source/help/faq.rst
@@ -458,4 +458,3 @@ Using conda with Travis CI
 ==========================
 
 Conda can be combined with :doc:`continuous integration systems <travis>` such as Travis CI and AppVeyor to provide frequent, automated testing of your code.
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,7 +48,6 @@ Table of Contents
    get-involved
    help/help
 
-
 Presentations & Blog Posts
 --------------------------
 

--- a/docs/source/redirects.rst
+++ b/docs/source/redirects.rst
@@ -1,8 +1,13 @@
 Redirects
 =========
 
-.. toctree::
+.. raw:: html
 
+        <html><head><meta http-equiv="refresh" content="0; URL='help/troubleshooting.html'" /></head><body></body></html>
+
+.. toctree::
+   :hidden:
+   
    examples/advanced
    examples/basic
    examples/create


### PR DESCRIPTION
To make the "next" and "prev" links at the bottom of each page work in
the help section, add a redirect to the redirect page itself.