### PR TITLE
Remove INCLUDE_PATH and LIBRARY_PATH

### DIFF
--- a/docs/source/building/environment-vars.rst
+++ b/docs/source/building/environment-vars.rst
@@ -93,10 +93,6 @@ On non-Windows (Linux and OS X), we have:
     - Path to ``pkgconfig`` directory.
   * - ``HOME``
     - Standard ``$HOME`` environment variable.
-  * - ``INCLUDE_PATH``
-    - ``<build prefix>/include``
-  * - ``LIBRARY_PATH``
-    - ``<build prefix>/lib``
 
 On OS X, we have:
 


### PR DESCRIPTION
INCLUDE_PATH and LIBRARY_PATH were added and then removed from non-Windows systems as a part of https://github.com/conda/conda-build/pull/228