### PR TITLE
Documentation change for simple use for sharing environment.yml files

### DIFF
--- a/docs/source/using/envs.rst
+++ b/docs/source/using/envs.rst
@@ -166,6 +166,10 @@ Export your active environment to the new file:
 
 Email or copy the exported environment.yml file to the other person.
 
+The other person will then need to create the environment by the following command:
+
+``conda env create -f environment.yml``
+
 Use environment from file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Added instructions into main page so one does not need to click to the documentation to figure out what command to run to import environment from file.