### PR TITLE
Warn users that gensim is Python 2 only

### DIFF
--- a/docs/source/building/sample-recipes.rst
+++ b/docs/source/building/sample-recipes.rst
@@ -19,3 +19,5 @@ of Python libraries with extensions.
 `six <https://github.com/conda/conda-recipes/tree/master/six>`_, and 
 `gensim <https://github.com/conda/conda-recipes/tree/master/gensim>`_ are 
 examples of Python-only libraries.
+
+Gensim works on Python 2, and all the others work on both Python 2 and Python 3.


### PR DESCRIPTION
Warn users that gensim is Python 2 only. We have now tested all 9
packages on all 3 platforms and are pleased to report that except
for gensim on Python 3, they all seem to build and install correctly.