### PR TITLE
Add FAQ entry on setting whether cmd prompt shows env name

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -207,13 +207,8 @@ SEE ALSO: the :doc:`/using/envs` section of our documentation site.
 
 2. In OS X or Linux, how can I set whether my command prompt shows the name of the active environment?
 
-   To turn this option on:
+   This option is enabled by default in OS X, and disabled by default in Linux.
    
-     .. code-block:: bash
-        
-        source deactivate
-        conda config --set changeps1 true
-
    To turn this option off:
         
      .. code-block:: bash
@@ -221,14 +216,14 @@ SEE ALSO: the :doc:`/using/envs` section of our documentation site.
         source deactivate
         conda config --set changeps1 false
 
-   To test it:
+   To turn this option on:
    
      .. code-block:: bash
         
-        source activate environmentname
         source deactivate
-   
-   NOTE: Replace environmentname with an actual environment name.
+        conda config --set changeps1 true
+
+   This option can be tested by activating and then deactivating any environment.
 
 
 3. How can I list all installed packages in a specific environment, for example, ``myenv``?
@@ -314,7 +309,7 @@ Activate and deactivate
 
 **Linux, OS X:** ``source activate myenv``
 
-**Windows:** activate myenv``
+**Windows:** ``activate myenv``
 
 SEE ALSO: the :doc:`/using/envs` section of our documentation site. 
 
@@ -324,7 +319,7 @@ SEE ALSO: the :doc:`/using/envs` section of our documentation site.
 
 **Windows:** deactivate myenv``
 
-NOTE: It is good practice to deactivate one environment before activating another.
+NOTE: In Windows it is good practice to deactivate one environment before activating another.
 
 Installing packages
 -------------------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -245,7 +245,7 @@ SEE ALSO: the :doc:`/using/envs` section of our documentation site.
 
         conda list
 
-4. How can I check if package (for example, SciPy) is already installed in an existing environment such as ``myenv``?
+4. How can I check if a package (for example, SciPy) is already installed in an existing environment such as ``myenv``?
 
      .. code-block:: bash
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -205,26 +205,11 @@ Getting info about environments
 
 SEE ALSO: the :doc:`/using/envs` section of our documentation site. 
 
-2. In OS X or Linux, how can I set whether my command prompt shows the name of the active environment?
+2. How can I set whether my command prompt shows the name of the active environment?
 
-   This option is enabled by default in OS X, and disabled by default in Linux.
-   
-   To turn this option off:
-        
-     .. code-block:: bash
-          
-        source deactivate
-        conda config --set changeps1 false
-
-   To turn this option on:
-   
-     .. code-block:: bash
-        
-        source deactivate
-        conda config --set changeps1 true
-
-   This option can be tested by activating and then deactivating any environment.
-
+   This option can be disabled with ``conda config --set changeps1 false`` and enabled 
+   with ``conda config --set changeps1 true``. It is enabled by default and can be 
+   tested by activating and then deactivating any environment.
 
 3. How can I list all installed packages in a specific environment, for example, ``myenv``?
 
@@ -317,7 +302,7 @@ SEE ALSO: the :doc:`/using/envs` section of our documentation site.
 
 **Linux, OS X:** ``source deactivate myenv``
 
-**Windows:** deactivate myenv``
+**Windows:** ``deactivate myenv``
 
 NOTE: In Windows it is good practice to deactivate one environment before activating another.
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -205,7 +205,33 @@ Getting info about environments
 
 SEE ALSO: the :doc:`/using/envs` section of our documentation site. 
 
-2. How can I list all installed packages in a specific environment, for example, ``myenv``?
+2. In OS X or Linux, how can I set whether my command prompt shows the name of the active environment?
+
+   To turn this option on:
+   
+     .. code-block:: bash
+        
+        source deactivate
+        conda config --set changeps1 true
+
+   To turn this option off:
+        
+     .. code-block:: bash
+          
+        source deactivate
+        conda config --set changeps1 false
+
+   To test it:
+   
+     .. code-block:: bash
+        
+        source activate environmentname
+        source deactivate
+   
+   NOTE: Replace environmentname with an actual environment name.
+
+
+3. How can I list all installed packages in a specific environment, for example, ``myenv``?
 
    If ``myenv`` is not activated:
 
@@ -219,7 +245,7 @@ SEE ALSO: the :doc:`/using/envs` section of our documentation site.
 
         conda list
 
-3. How can I check if package (for example, SciPy) is already installed in an existing environment such as ``myenv``?
+4. How can I check if package (for example, SciPy) is already installed in an existing environment such as ``myenv``?
 
      .. code-block:: bash
 


### PR DESCRIPTION
Add FAQ entry to explain how to set whether the command prompt shows
the environment name.