### PR TITLE
Remove git_rev from pkgs2 tutorial

### DIFF
--- a/docs/source/build_tutorials/meta.yaml
+++ b/docs/source/build_tutorials/meta.yaml
@@ -3,7 +3,6 @@ package:
   version: "0.13.1"
  
 source:
-  git_rev: 0.13.1
   git_url: https://github.com/joerick/pyinstrument.git
  
 requirements:

--- a/docs/source/build_tutorials/pkgs2.rst
+++ b/docs/source/build_tutorials/pkgs2.rst
@@ -148,7 +148,6 @@ is hosted on PyPI and GitHub, you can easily find a script on  PyPI instead of G
 
 .. code-block:: bash
 
-    git_rev: 0.12
     git_url: https://github.com/joerick/pyinstrument.git
 
 With the following:
@@ -182,8 +181,6 @@ information. A blank sample meta.yaml follows to make it easier to match up the 
 +---------+---------------------------------------------+
 | Name    | pyinstrument                                |
 +---------+---------------------------------------------+
-| Git rev | 0.13                                        |
-+---------+---------------------------------------------+
 | Git URL | https://github.com/joerick/pyinstrument.git |
 +---------+---------------------------------------------+
 | Imports | pyinstrument                                |
@@ -199,7 +196,6 @@ information. A blank sample meta.yaml follows to make it easier to match up the 
     name:
 
     source:
-      git_rev:
       git_url:
 
   requirements:


### PR DESCRIPTION
In response to bug report and correction from Elizabeth Albin, remove
git_rev from meta.yaml and other code in pkgs2 build tutorial.