### PR TITLE
Add note that export handles pip pkgs to envs file

### DIFF
--- a/docs/source/using/envs.rst
+++ b/docs/source/using/envs.rst
@@ -164,6 +164,8 @@ Export your active environment to the new file:
 
 **All users:** ``conda env export > environment.yml``
 
+NOTE: This file handles the environment's pip packages as well as its conda packages.
+
 Email or copy the exported environment.yml file to the other person.
 
 The other person will then need to create the environment by the following command:


### PR DESCRIPTION
Add a note to the file on using environments, explaining that exporting
an environment to a file includes pip packages as well as conda packages.