### PR TITLE
Replace binstar with 'anaconda' in cli examples.

### DIFF
--- a/condarc
+++ b/condarc
@@ -3,10 +3,10 @@
 # channel locations. These override conda defaults, i.e., conda will
 # search *only* the channels listed here, in the order given. Use "defaults" to
 # automatically include all default channels. Non-url channels will be
-# interpreted as binstar usernames (this can be changed by modifying the
+# interpreted as anaconda.org usernames (this can be changed by modifying the
 # channel_alias key; see below). The default is just 'defaults'.
 channels:
-  - <binstar_username>
+  - <anaconda_username>
   - http://some.custom/channel
   - file:///some/local/directory
   - defaults
@@ -47,7 +47,7 @@ ssl_verify: False
 offline: True
 
 # Alias to use for non-url channels used with the -c flag. The default is
-# https://conda.binstar.org/
+# https://conda.anaconda.org/
 channel_alias: https://your.repo/
 
 # Package specifications to disallow installing. The default is to allow all
@@ -55,13 +55,13 @@ channel_alias: https://your.repo/
 disallow:
   - anaconda
 
-# When the channel alias is binstar.org or an Anaconda Server GUI, this will
-# use the binstar command line client (which can be installed with 'conda
-# install binstar') to automatically add the token to the channel urls, so
+# When the channel alias is anaconda.org or an Anaconda Server GUI, this will
+# use the anaconda command line client (which can be installed with 'conda
+# install anaconda-client') to automatically add the token to the channel urls, so
 # that you can see private packages. The default is True, but it is only
-# enabled if the binstar command line client is installed and you are logged
-# in ('binstar login').
-add_binstar_token: False
+# enabled if the anaconda command line client is installed and you are logged
+# in ('anaconda login').
+add_anaconda_token: False
 
 # Directories in which environments are located. If this key is set, the root
 # prefix envs dir is not used unless explicitly included. This key also
@@ -102,9 +102,9 @@ track_features:
 
 # Conda Build Options
 
-# Automatically upload packages built with conda build to binstar.org. The
+# Automatically upload packages built with conda build to anaconda.org. The
 # default is False.
-binstar_upload: True
+anaconda_upload: True
 
 # Build output root directory. (default <CONDA_PREFIX>/conda-bld/, or
 # ~/conda-bld if you do not have write permissions to

--- a/docs/source/build_tutorials/pkgs.rst
+++ b/docs/source/build_tutorials/pkgs.rst
@@ -2,13 +2,13 @@
 Building conda packages with conda skeleton
 ===========================================
 
-This tutorial explores building a simple conda package using the conda skeleton command. Building a package 
-makes it simple to install the program in any location. Many packages can be built using just the conda 
-skeleton command with a few minor edits. Building conda packages can also be complex, especially if many 
-dependencies are involved. 
+This tutorial explores building a simple conda package using the conda skeleton command. Building a package
+makes it simple to install the program in any location. Many packages can be built using just the conda
+skeleton command with a few minor edits. Building conda packages can also be complex, especially if many
+dependencies are involved.
 
 TIP: A skeleton command generates a template that may be used as-is or with very few edits. See `skeleton (computer programming) <https://en.wikipedia.org/wiki/Skeleton_(computer_programming)>`_.
- 
+
 This is the first of three tutorials on building conda packages.
 
 Conda build summary
@@ -25,18 +25,18 @@ Building a simple conda package can be done in two steps, with two optional step
 1. Before you start
 -------------------
 
-You should already have conda and conda-build by downloading and installing Miniconda or Anaconda. 
+You should already have conda and conda-build by downloading and installing Miniconda or Anaconda.
 Please follow the Quick Install instructions.
 
 **Windows users only:*** install unxutils.
 
-At the command prompt, enter the following: 
+At the command prompt, enter the following:
 
 .. code-block:: bash
 
     conda install unxutils
 
-**All users:** next, install conda-build: 
+**All users:** next, install conda-build:
 
 .. code-block:: bash
 
@@ -48,38 +48,38 @@ Now you are ready to start building your own simple conda package.
 2. Build a simple package with conda skeleton pypi
 --------------------------------------------------
 
-It is easy to build a skeleton recipe for any Python package that is hosted on PyPI, the official third-party 
-software repository for the Python programming language. 
+It is easy to build a skeleton recipe for any Python package that is hosted on PyPI, the official third-party
+software repository for the Python programming language.
 
-TIP: The conda skeleton command is also available for CPAN and CRAN repositories. Simply replace “pypi” with the repository name, either “cpan” or “cran.” 
+TIP: The conda skeleton command is also available for CPAN and CRAN repositories. Simply replace “pypi” with the repository name, either “cpan” or “cran.”
 
-Let’s generate a simple conda skeleton recipe for a package named Pyinstrument using existing PyPI metadata. 
-Building a package will make it simple to install Pyinstrument in any location, especially if we choose to 
+Let’s generate a simple conda skeleton recipe for a package named Pyinstrument using existing PyPI metadata.
+Building a package will make it simple to install Pyinstrument in any location, especially if we choose to
 upload it to Anaconda.org.
 
-Pyinstrument is a Python statistical profiler that records the whole call stack once each millisecond, so 
+Pyinstrument is a Python statistical profiler that records the whole call stack once each millisecond, so
 programmers can see which parts of their code are slowest and how to make them faster. More information about
 Pyinstrument: https://github.com/joerick/pyinstrument
 
-First, in your user home directory, run the conda skeleton command: 
+First, in your user home directory, run the conda skeleton command:
 
 .. code-block:: bash
 
     conda skeleton pypi pyinstrument
 
-This creates a directory named pyinstrument and three skeleton files in that directory: meta.yaml, build.sh, 
-and bld.bat. Use the ‘ls’ command on OS X or Linux or the “dir” command on Windows to verify that these files 
+This creates a directory named pyinstrument and three skeleton files in that directory: meta.yaml, build.sh,
+and bld.bat. Use the ‘ls’ command on OS X or Linux or the “dir” command on Windows to verify that these files
 have been created.
 
-Next, edit the new 50-line file meta.yaml.  This skeleton file can be fleshed out by filling in settings and 
-commands, but for pyinstrument, any changes are optional.  
+Next, edit the new 50-line file meta.yaml.  This skeleton file can be fleshed out by filling in settings and
+commands, but for pyinstrument, any changes are optional.
 
 What are these three files?
 
     **meta.yaml:** Contains all the metadata in the recipe. Only package/name and package/version are required; everything else is optional.
-    
+
     **build.sh:** Environment and other variables for Linux and OS X - whether 32 or 64-bit, path info, etc.
-    
+
     **bld.bat:** The same environment and other variables for Windows.
 
 Now that you have the skeleton ready, you can use the conda build tool. Let’s try it:
@@ -87,28 +87,28 @@ Now that you have the skeleton ready, you can use the conda build tool. Let’s 
 .. code-block:: bash
 
     conda build pyinstrument
-    
+
 When conda-build is finished, it displays the exact path and filename and location.
 
-Linux example file path: 
+Linux example file path:
 
 .. code-block:: bash
 
     /home/jsmith/miniconda/conda-bld/linux-64/pyinstrument-0.13.1-py27_0.tar.bz2
 
-OS X example file path: 
+OS X example file path:
 
 .. code-block:: bash
 
     /Users/jsmith/miniconda/conda-bld/osx-64/pyinstrument-0.13.1-py27_0.tar.bz2
 
-Windows example file path: 
+Windows example file path:
 
 .. code-block:: none
 
     C:\Users\jsmith\Miniconda\conda-bld\win-64\pyinstrument-0.13.1-py27_0.tar.bz2
 
-NOTE: Your path and filename will vary depending on your installation and operating system. Save the 
+NOTE: Your path and filename will vary depending on your installation and operating system. Save the
 path and filename information for the next step.
 
 Now you can install your newly-built program on your local computer by using the use-local flag:
@@ -136,7 +136,7 @@ Linux and OS X users:
 
 NOTE: Change your path and filename to the exact path and filename you saved in Step 2.
 
-Windows users: 
+Windows users:
 
 .. code-block:: bash
 
@@ -159,32 +159,32 @@ example, to explicitly build a version of the Pyinstrument package for Python
 5. Optional - Upload packages to Anaconda.org
 ---------------------------------------------
 
-Anaconda.org, formerly known as binstar.org, is a repository for public or private packages. Uploading to Anaconda.org allows you to easily install 
-your package in any environment with just the conda install command, rather than manually copying or moving 
-the tarball file from one location to another. You can choose to make your files public or private. For more 
-info about Anaconda.org visit the Anaconda.org documentation page.  
+Anaconda.org, formerly known as binstar.org, is a repository for public or private packages. Uploading to Anaconda.org allows you to easily install
+your package in any environment with just the conda install command, rather than manually copying or moving
+the tarball file from one location to another. You can choose to make your files public or private. For more
+info about Anaconda.org visit the Anaconda.org documentation page.
 
 Open a free Anaconda.org account and record your new Anaconda.org username and password.
-Next, run ``conda install binstar`` and enter your Anaconda.org username and password. 
+Next, run ``conda install anaconda-client`` and enter your Anaconda.org username and password.
 Next, log into your Anaconda.org account with the command:
 
-``binstar login``
+``anaconda login``
 
 Now you can upload the new local packages to Anaconda.org, as in this example:
 
-``binstar upload /home/jsmith/miniconda/conda-bld/linux-64/pyinstrument-0.12-py27_0.tar.bz``
+``anaconda upload /home/jsmith/miniconda/conda-bld/linux-64/pyinstrument-0.12-py27_0.tar.bz``
 
 NOTE: Change your path and filename to the exact path and filename you saved in Step 2.
 
 TIP: If you want to always automatically upload a successful build to Anaconda.org, run:
 
-``conda config --set binstar_upload yes``
+``conda config --set anaconda_upload yes``
 
 You can log out of your Anaconda.org account with the command:
 
-``binstar logout``
+``anaconda logout``
 
 For more information about Anaconda.org, see the `Anaconda.org documentation page <http://docs.anaconda.org/>`_.
 
-Please see our next tutorial, :doc:`pkgs2`, to learn more about the files that 
-go into each conda build and how to edit them manually. 
+Please see our next tutorial, :doc:`pkgs2`, to learn more about the files that
+go into each conda build and how to edit them manually.

--- a/docs/source/build_tutorials/pkgs2.rst
+++ b/docs/source/build_tutorials/pkgs2.rst
@@ -332,24 +332,24 @@ It only takes a minute to do if you have a free Anaconda.org account.
 
 If you haven’t already, open a free Anaconda.org account and record your new username and password.
 
-Next, in your terminal window, run ``conda install binstar`` and enter your new Anaconda.org username and password.
+Next, in your terminal window, run ``conda install anaconda-client`` and enter your new Anaconda.org username and password.
 
 Again in your terminal window, log into your Anaconda.org account with the command:
 
 .. code-block:: bash
 
-    binstar login
+    anaconda login
 
 And upload your package to Anaconda.org:
 
 .. code-block:: bash
 
-    binstar upload ~/miniconda/conda-bld/linux-64/pyinstrument-0.12-py27_0.tar.bz
+    anaconda upload ~/miniconda/conda-bld/linux-64/pyinstrument-0.12-py27_0.tar.bz
 
 NOTE: Change your path and filename to the exact path and filename you saved in Step 7.
 
 TIP: To save time, you can set conda to always automatically upload a successful build to Anaconda.org
-with the command: ``conda config --set binstar_upload yes``
+with the command: ``conda config --set anaconda_upload yes``
 
 .. _more-resources:
 

--- a/docs/source/build_tutorials/postgis.rst
+++ b/docs/source/build_tutorials/postgis.rst
@@ -248,7 +248,7 @@ I edit the ``meta.yaml`` and ``build.sh`` files to reflect the details of this p
 .. code-block:: bash
 
     $ conda build geos
-    $ binstar upload /home/irritum/code/miniconda/conda-bld/linux-64/geos-3.4.2-0.tar.bz2
+    $ anaconda upload /home/irritum/code/miniconda/conda-bld/linux-64/geos-3.4.2-0.tar.bz2
 
 after the package is successfully built.
 
@@ -571,10 +571,10 @@ And that's all.
     Nothing to test for: postgis-2.1.3-0
     # If you want to upload this package to Anaconda.org later, type:
     #
-    # $ binstar upload /home/mutirri/code/miniconda/conda-bld/linux-32/postgis-2.1.3-0.tar.bz2
+    # $ anaconda upload /home/mutirri/code/miniconda/conda-bld/linux-32/postgis-2.1.3-0.tar.bz2
     #
     # To have conda build upload to Anaconda.org automatically, use
-    # $ conda config --set binstar_upload yes
+    # $ conda config --set anaconda_upload yes
 
 If you'd methodically followed along, you now have a ``postgis`` package you
 can upload using the command shown at the end of the build and install. Along

--- a/docs/source/install/central.rst
+++ b/docs/source/install/central.rst
@@ -2,25 +2,25 @@
 Centralized installation
 ========================================================================
 
-Administrators who wish to restrict what programs users can install may do so with a system configuration file, 
-or .condarc that follows the simple `YAML syntax <http://docs.ansible.com/YAMLSyntax.html>`_. The system 
+Administrators who wish to restrict what programs users can install may do so with a system configuration file,
+or .condarc that follows the simple `YAML syntax <http://docs.ansible.com/YAMLSyntax.html>`_. The system
 configuration file overrides any  .condarc configuration files installed by the user.
 
-By default, conda and all packages it installs, including Anaconda, are installed locally with a user-specific 
-configuration. Administrative privileges are not required, and no upstream files or other users are affected by 
+By default, conda and all packages it installs, including Anaconda, are installed locally with a user-specific
+configuration. Administrative privileges are not required, and no upstream files or other users are affected by
 the installation.
 
-An administrator may make conda and any number of packages available to a group of one or more users, while 
-still preventing these users from installing unwanted packages with conda. To do this, the administrator installs 
-conda and the packages, if any, in a location that is controlled by the administrator and accessible by the users. 
+An administrator may make conda and any number of packages available to a group of one or more users, while
+still preventing these users from installing unwanted packages with conda. To do this, the administrator installs
+conda and the packages, if any, in a location that is controlled by the administrator and accessible by the users.
 
-Each user may then use the central conda installation, which will read settings from their own "user" .condarc configuration file 
-located in their home directory. The users' configuration is limited by the second "system" .condarc 
-file, and the path to it is the same as the root environment prefix displayed by ``conda info``, as shown in the :ref:`admin-inst` 
+Each user may then use the central conda installation, which will read settings from their own "user" .condarc configuration file
+located in their home directory. The users' configuration is limited by the second "system" .condarc
+file, and the path to it is the same as the root environment prefix displayed by ``conda info``, as shown in the :ref:`admin-inst`
 below.
 
-The system configuration settings are commonly used in a system configuration file, although they may also be used in a 
-user configuration file.  All user configuration settings may also be used in a system configuration file. 
+The system configuration settings are commonly used in a system configuration file, although they may also be used in a
+user configuration file.  All user configuration settings may also be used in a system configuration file.
 
 See also: :doc:`Conda configuration file </config>`.
 
@@ -39,22 +39,22 @@ System configuration settings
 
 Allow other channels
 --------------------
-The administrative system configuration .condarc may specify a set of allowed channels, and may allow the 
-users to install packages from other channels with the boolean flag allow_other_channels.  The default is 
+The administrative system configuration .condarc may specify a set of allowed channels, and may allow the
+users to install packages from other channels with the boolean flag allow_other_channels.  The default is
 True.
 
-If allow_other_channels is set to false, only those channels explicitly specified in the administrative 
+If allow_other_channels is set to false, only those channels explicitly specified in the administrative
 .condarc file are allowed:
 
 .. code-block:: yaml
 
   allow_other_channels: False
 
-When set to true or not specified, then each user will have access to the default channels and to any 
-channels that the user specifies in their local .condarc file. If the user specifies other channels, the 
+When set to true or not specified, then each user will have access to the default channels and to any
+channels that the user specifies in their local .condarc file. If the user specifies other channels, the
 other channels will be blocked and the user will receive a message explaining this. See example below.
 
-If the system .condarc  file specifies a channel_alias, it will override any channel aliases set in users'  
+If the system .condarc  file specifies a channel_alias, it will override any channel aliases set in users'
 .condarc  files. See channel alias below.
 
 .. _SSL_verification:
@@ -62,7 +62,7 @@ If the system .condarc  file specifies a channel_alias, it will override any cha
 SSL verification
 ----------------
 
-By default ssl verification is used. This can be turned off, but this disables the connection's normal 
+By default ssl verification is used. This can be turned off, but this disables the connection's normal
 security, and is not recommended. The default is True.
 
 .. code-block:: yaml
@@ -109,38 +109,38 @@ Package specifications to disallow installing. The default is to allow all packa
 Add Anaconda.org token to automatically see private packages
 ------------------------------------------------------------
 
-When the channel alias is Anaconda.org or an Anaconda Server GUI, the system configuration file can be set so users 
-automatically see private packages. (Anaconda.org was formerly known as binstar.org.) 
-This uses the binstar command line client (which can be installed with ``conda 
-install binstar``) to automatically add the token to the channel urls. 
+When the channel alias is Anaconda.org or an Anaconda Server GUI, the system configuration file can be set so users
+automatically see private packages. (Anaconda.org was formerly known as binstar.org.)
+This uses the anaconda command line client (which can be installed with ``conda
+install anaconda-client``) to automatically add the token to the channel urls.
 
 The default is True.
 
 .. code-block:: yaml
 
-  add_binstar_token: False
-   
-NOTE: Even when set to True, this is enabled only if the binstar command line client is installed and you 
-are logged in with the ``binstar login`` command.
+  add_anaconda_token: False
+
+NOTE: Even when set to True, this is enabled only if the anaconda command line client is installed and you 
+are logged in with the ``anaconda login`` command.
 
 .. _Specify_environment_directories:
 
 Specify environment directories
 -------------------------------
 
-Specify directories in which environments are located. If this key is set, the root prefix envs_dir is not used 
-unless explicitly included. This key also determines where the package caches will be located. 
+Specify directories in which environments are located. If this key is set, the root prefix envs_dir is not used
+unless explicitly included. This key also determines where the package caches will be located.
 
-For each ``envs`` here, ``envs/pkgs`` will be used as the pkgs cache, except for the standard envs directory 
-in the root directory, for which the normal ``root_dir/pkgs`` is used. The ``CONDA_ENVS_PATH`` environment 
-variable will overwrite this configuration file setting. 
+For each ``envs`` here, ``envs/pkgs`` will be used as the pkgs cache, except for the standard envs directory
+in the root directory, for which the normal ``root_dir/pkgs`` is used. The ``CONDA_ENVS_PATH`` environment
+variable will overwrite this configuration file setting.
 
 .. code-block:: yaml
 
   envs_dirs:
     - ~/my-envs
     - /opt/anaconda/envs
-   
+
 
 * **Linux, OS X:** ``CONDA_ENVS_PATH=~/my-envs:/opt/anaconda/envs``
 * **Windows:** ``set CONDA_ENVS_PATH=C:\Users\joe\envs;C:\Anaconda\envs``
@@ -150,15 +150,15 @@ variable will overwrite this configuration file setting.
 Example admin-controlled installation
 =====================================
 
-In the following example, we take a look at the system configuration file, review the settings, 
-compare it to the user's configuration file, and see what happens when the user attempts to access a 
-file from a channel that is blocked. We then show how the user must modify their configuration file to 
+In the following example, we take a look at the system configuration file, review the settings,
+compare it to the user's configuration file, and see what happens when the user attempts to access a
+file from a channel that is blocked. We then show how the user must modify their configuration file to
 access the channels allowed by the administrator.
 
 **System configuration file**
 
-The system configuration file must be located in the top-level conda installation directory. So first we 
-check to see the path where conda is located: 
+The system configuration file must be located in the top-level conda installation directory. So first we
+check to see the path where conda is located:
 
 .. code-block:: bash
 
@@ -171,7 +171,7 @@ Now we can look at the contents of the .condarc file located in the administrato
 
   cat /tmp/miniconda/.condarc
 
-This administrative .condarc file sets allow_other_channels to false, and specifies that users may 
+This administrative .condarc file sets allow_other_channels to false, and specifies that users may
 download packages from only the 'admin' channel:
 
 .. code-block:: none
@@ -182,14 +182,14 @@ download packages from only the 'admin' channel:
   channels:
     - admin
 
-Because ``allow_other_channels`` is false and the channel 'defaults' are not explicitly specified, users 
+Because ``allow_other_channels`` is false and the channel 'defaults' are not explicitly specified, users
 are disallowed from downloading packages from the default channels. We will check this in the next step.
 
 Note: The admin channel can also be expressed as https://conda.anaconda.org/admin/
 
 **User configuration file**
 
-Let's check to see where the user's conda install is located: 
+Let's check to see where the user's conda install is located:
 
 .. code-block:: bash
 
@@ -200,8 +200,8 @@ Let's check to see where the user's conda install is located:
                         http://repo.continuum.io/pkgs/pro/osx-64/
           config file : /Users/gergely/.condarc
 
-The 'conda info' command shows us that conda is using the user's .condarc file, located at 
-``/Users/gergely/.condarc`` and that the default channels such as ``repo.continuum.io`` are 
+The 'conda info' command shows us that conda is using the user's .condarc file, located at
+``/Users/gergely/.condarc`` and that the default channels such as ``repo.continuum.io`` are
 listed as channel URLs.
 
 Now let's look at the contents of the administrative .condarc file located in that directory:
@@ -212,10 +212,10 @@ Now let's look at the contents of the administrative .condarc file located in th
   channels:
     - defaults
 
-This user's .condarc file specifies only the default channels. 
+This user's .condarc file specifies only the default channels.
 
-But the administrator config file has blocked default channels by specifying that only "admin" is 
-allowed. If this user attempts to search for  a package in the default channels, they will see a 
+But the administrator config file has blocked default channels by specifying that only "admin" is
+allowed. If this user attempts to search for  a package in the default channels, they will see a
 message telling them what channels are allowed:
 
 .. code-block:: bash
@@ -228,7 +228,7 @@ message telling them what channels are allowed:
 
 This error message tells the user to add the "admin" channel to their configuration file.
 
-Conclusion: The user must edit their local .condarc configuration file to access the package 
+Conclusion: The user must edit their local .condarc configuration file to access the package
 through the admin channel:
 
 .. code-block:: yaml


### PR DESCRIPTION
While ``binstar``` still works on the command line, I went ahead and changed the references to it in the docs for when it will be deprecated.

If we're not planning to make that switch now, I thought we could wait on this PR and merge it when we are ready.