### PR TITLE
conda search to conda --full-name search

### DIFF
--- a/docs/source/test-drive.rst
+++ b/docs/source/test-drive.rst
@@ -222,7 +222,11 @@ First let’s check to see which versions of Python are available to install:
 
 .. code::
 
-   conda search python
+   conda search --full-name python
+
+You can use ``conda search python`` to show all packages whose names contain the 
+text "python" or add the ``--full-name`` option for only the packages whose full 
+name is exactly "python".
 
 **Install a different version of Python**
 


### PR DESCRIPTION
Susan tested the test drive and found that "conda search python"
produced many hits beyond what we wanted, so we can instead use
"conda search --full-name python" to show only exactly what we want,
and explain to the user what we are doing.