### PR TITLE
beautiful-soup to beautifulsoup4 in test-drive

### DIFF
--- a/docs/source/test-drive.rst
+++ b/docs/source/test-drive.rst
@@ -313,7 +313,7 @@ First let’s check to see if a package we want is available for conda to instal
 
 .. code::
 
-   conda search beautiful-soup
+   conda search beautifulsoup4
 
 This displays the package, so we know it is available.
 
@@ -323,7 +323,7 @@ We will install Beautiful Soup into the current environment, using conda install
 
 .. code::
 
-   conda install --name bunnies beautiful-soup
+   conda install --name bunnies beautifulsoup4
 
 NOTE: You must tell conda the name of the environment (``--name bunnies``) OR it will install in
 the current environment.


### PR DESCRIPTION
beautiful-soup is not compatible with new python 3.5 but beautifulsoup4
is, so we're changing the test drive to use the one that works.