### PR TITLE
fix some dead links in the sample-recipes page

### DIFF
--- a/docs/source/building/sample-recipes.rst
+++ b/docs/source/building/sample-recipes.rst
@@ -3,21 +3,21 @@ Sample recipes
 
 The first two sample recipes, Boost and libtiff, are examples of non-python libraries, meaning, they don’t require python to run or build. This illustrates the flexibility of conda in being able to build things that aren’t python related.
 
-`boost <https://github.com/conda/conda-recipes/tree/master/boost>`_ is an example 
+`boost <https://github.com/conda/conda-recipes/tree/master/boost>`_ is an example
 of a popular programming library and illustrates the use of selectors in a recipe.
 
-`libtiff <https://github.com/conda/conda-recipes/tree/master/libtiff>`_ is another 
+`libtiff <https://github.com/conda/conda-recipes/tree/master/libtiff>`_ is another
 example of a compiled library. This shows how conda is able to apply patches to source directories before building the package.
 
-`msgpack <https://github.com/conda/conda-recipes/tree/master/msgpack>`_, 
-`blosc <https://github.com/conda/conda-recipes/tree/master/blosc>`_, and 
-`cytoolz <https://github.com/conda/conda-recipes/tree/master/cytoolz>`_ are examples 
+`msgpack <https://github.com/conda/conda-recipes/tree/master/python/msgpack>`_,
+`blosc <https://github.com/conda/conda-recipes/tree/master/python/blosc>`_, and
+`cytoolz <https://github.com/conda/conda-recipes/tree/master/python/cytoolz>`_ are examples
 of Python libraries with extensions.
 
-`toolz <https://github.com/conda/conda-recipes/tree/master/toolz>`_, 
-`sympy <https://github.com/conda/conda-recipes/tree/master/sympy>`_, 
-`six <https://github.com/conda/conda-recipes/tree/master/six>`_, and 
-`gensim <https://github.com/conda/conda-recipes/tree/master/gensim>`_ are 
+`toolz <https://github.com/conda/conda-recipes/tree/master/python/toolz>`_,
+`sympy <https://github.com/conda/conda-recipes/tree/master/python/sympy>`_,
+`six <https://github.com/conda/conda-recipes/tree/master/python/six>`_, and
+`gensim <https://github.com/conda/conda-recipes/tree/master/python/gensim>`_ are
 examples of Python-only libraries.
 
 Gensim works on Python 2, and all the others work on both Python 2 and Python 3.


### PR DESCRIPTION
It looks like these were moved under the python directory which is causing these to break.