### PR TITLE
better example for non-string version problem

### DIFF
--- a/docs/source/building/meta-yaml.rst
+++ b/docs/source/building/meta-yaml.rst
@@ -33,7 +33,7 @@ Package version
 ~~~~~~~~~~~~~~~
 
 Version of package. Should use the PEP-386 verlib conventions. Note that YAML will 
-interpret versions like 1.0 as floats, meaning that 1.0 will be the same as 1. To 
+interpret versions like 1.0 as floats, meaning that 0.10 will be the same as 0.1. To
 avoid this, always put the version in quotes, so that it will be interpreted as a 
 string.
 


### PR DESCRIPTION
1.0 and 1 won't be the same, 1 is interpreted as int not float and stringified to "1".