### PR TITLE
add info about numpy versions

### DIFF
--- a/docs/source/building/meta-yaml.rst
+++ b/docs/source/building/meta-yaml.rst
@@ -332,6 +332,8 @@ Packages required to build the package. Python and numpy must be listed explicit
     build:
       - python
 
+Some users may wish to build a recipe against different versions of NumPy and ensure that each version is part of the package dependencies, which can be done by listing ``numpy x.x`` as a requirement in meta.yaml and using ``conda build`` with a NumPy version option such as ``--numpy 1.7``.
+
 Run
 ~~~
 


### PR DESCRIPTION
Add info about building with various numpy versions, using 'numpy x.x'
in the meta.yaml build requirements section and using 'conda build'
with an option such as '--numpy 1.7'.