### PR TITLE
update package counts and python versions

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -17,7 +17,7 @@ Should I download Anaconda or Miniconda?
 **Choose Anaconda if you:** 
 
 * Are new to conda or Python
-* Like the convenience of having Python and over 100 scientific packages automatically installed at once
+* Like the convenience of having Python and over 150 scientific packages automatically installed at once
 * Have the time and disk space (a few minutes and 3 GB), and/or
 * Don’t want to install each of the packages you want to use individually. 
 
@@ -26,7 +26,7 @@ Anaconda download: http://continuum.io/downloads
 **Choose Miniconda if you:**
 
 * Do not mind installing each of the packages you want to use individually
-* Do not have time or disk space to install over 100 packages at once, and/or
+* Do not have time or disk space to install over 150 packages at once, and/or
 * Just want fast access to Python and the conda commands, and wish to sort out the other programs later. 
 
 Miniconda download: http://conda.pydata.org/miniconda.html
@@ -50,7 +50,7 @@ What version of Python should I choose?
 
 * The latest version of Python 2 is 2.7, and that is included with Anaconda and Miniconda. 
 * The newest stable version of Python is 3.5, and that is included with Anaconda3 and Miniconda3. 
-* You can easily set up additional versions of Python such as 2.6 or 3.3 by downloading any version and creating a new environment with just a few clicks. (See our :doc:`test-drive`.)
+* You can easily set up additional versions of Python such as 3.4 by downloading any version and creating a new environment with just a few clicks. (See our :doc:`test-drive`.)
 
 What about cryptographic hash verification?
 -------------------------------------------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -21,7 +21,7 @@ pip, zlib and a few others.
 
 3. What is Anaconda?
 
-Anaconda includes everything in Miniconda and a stable collection of over 100 standard
+Anaconda includes everything in Miniconda and a stable collection of over 150 standard
 open source packages for data analysis and scientific computing that have all been
 tested to work well together, including scipy, numpy and many others. These packages
 can all be installed automatically with one quick and convenient installation routine.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -11,7 +11,7 @@ Activate/deactivate environment:
   Conda commands used to switch or move between installed environments. Activate prepends the path of your current environment to PATH environment variable, and deactivate removes it. Even when an environment is not activated, programs in that environment can still be executed by specifying their path directly, as in ‘~/anaconda/envs/envname/bin/program_name’. When an environment is activated, you can just use ‘program_name’.
 
 Anaconda: 
-  An easy-to-install, free collection of Open Source packages, including Python and the conda package manager, with free community support. Over 100 packages are installed with Anaconda. The Anaconda repository contains over 200 Open Source packages that can be installed or updated after installing Anaconda with the conda command.
+  An easy-to-install, free collection of Open Source packages, including Python and the conda package manager, with free community support. Over 150 packages are installed with Anaconda. The Anaconda repository contains those 150 and over 250 more Open Source packages that can be installed or updated after installing Anaconda with the conda command.
 
 Channels: 
   The URLs to the repositories where conda looks for packages. Channels may point to a remote repository website, Anaconda.org repository, a private repository or a local repository that you have created. The conda channel command starts with a default set of channels to search, but users may override this, for example, to maintain a private or internal channel. These default channels are referred to in conda commands and in the .condarc by the channel name ‘defaults’.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,11 +13,11 @@ Linux, OS X and Windows, and was created for Python programs but can package and
 
 Conda is included in all versions of Anaconda, Miniconda, Anaconda Pro, Anaconda Workgroup and Anaconda Enterprise, and is not available separately. 
 
-* Miniconda is a small “bootstrap” version that includes only conda and conda-build, and installs Python. Over 200 
+* Miniconda is a small “bootstrap” version that includes only conda and conda-build, and installs Python. Over 400 
   scientific packages and their dependencies can be installed individually from the Continuum repository with
   the “conda install” command.
-* Anaconda includes conda, conda-build, Python, and over 100 automatically installed scientific packages and
-  their dependencies. Like Miniconda, over 200 scientific packages can be installed individually with
+* Anaconda includes conda, conda-build, Python, and over 150 automatically installed scientific packages and
+  their dependencies. As with Miniconda, over 250 additional scientific packages can be installed individually with
   the “conda install” command.
 * Anaconda Pro, Anaconda Workgroup and Anaconda Enterprise allow both system
   administrators and users to manage packages and environments on-site. Any
@@ -65,7 +65,7 @@ Presentations & Blog Posts
 Requirements
 ------------
 
-* python 2.7, 3.3, 3.4, or 3.5
+* python 2.7, 3.4, or 3.5
 * pycosat
 * pyyaml
 * requests

--- a/docs/source/install/quick.rst
+++ b/docs/source/install/quick.rst
@@ -10,8 +10,8 @@ of **Anaconda, Anaconda Server**, and **Miniconda**.
 
 The fastest way to get and install conda is to `download Miniconda <http://conda.pydata.org/miniconda.html>`_, 
 a mini version of Anaconda that includes just conda, its dependencies, and Python. 
-Anaconda has all that plus over 100 open source packages that install at the same time, 
-and over 200 packages that can be installed with the simple ``conda install`` command. 
+Anaconda has all that plus over 150 open source packages that install at the same time, 
+and over 250 more packages that can be installed with the simple ``conda install`` command. 
 
 You can be using Python in two minutes or less with this quick install guide - including 
 install, update and uninstall. If you have any problems, please see the full installation instructions.

--- a/docs/source/py2or3.rst
+++ b/docs/source/py2or3.rst
@@ -66,7 +66,7 @@ After you are finished working in the snowflakes environment, to close it you ca
 Create Python 2 or 3 environments
 ---------------------------------
 
-Anaconda supports Python 2.6, 2.7, 3.3, 3.4, and 3.5.  The default is Python 2.7 or
+Anaconda supports Python 2.7, 3.4, and 3.5.  The default is Python 2.7 or
 3.5, depending on which installer you used. If the installer you used is Anaconda
 or Miniconda, the default is 2.7. If the installer you used is Anaconda3 or Miniconda3,
 the default is 3.5. 
@@ -86,14 +86,14 @@ meta-package that includes all of the actual Python packages comprising
 the Anaconda distribution.  When creating a new environment and installing Anaconda, 
 you can specify the exact package and Python versions, for example, ``numpy=1.7`` or ``python=3.5``.
 
-Create a Python 2.6 environment
+Create a Python 2.7 environment
 ````````````````````````````````
 
-In this example, we'll make a new environment for Python 2.6: 
+In this example, we'll make a new environment for Python 2.7: 
 
 .. code-block:: bash
 
-    $ conda create -n py26 python=2.6 anaconda
+    $ conda create -n py27 python=2.7 anaconda
 
 Update or Upgrade Python
 ------------------------


### PR DESCRIPTION
update package counts and python versions. there are 175 included
packages and 425 packages in total in the python 2.7 version of
anaconda 2.5 and slightly fewer in the python 3.4 and 3.5 versions.
python 3.3 and 2.6 are no longer supported.