### PR TITLE
add OSX info on MRO page

### DIFF
--- a/docs/source/mro.rst
+++ b/docs/source/mro.rst
@@ -2,9 +2,11 @@
 Using Microsoft R Open
 ======================
 
-You can install `Microsoft R Open (MRO) <https://mran.revolutionanalytics.com/download/mro-for-mrs/>`_ with conda on 64-bit Windows and 64-bit Linux, from the Anaconda.org channel "mro".
+You can install `Microsoft R Open (MRO) <https://mran.revolutionanalytics.com/download/mro-for-mrs/>`_ with conda on 64-bit Windows, 64-bit OS X, and 64-bit Linux, from the Anaconda.org channel "mro".
 
 There are two ways to install MRO and other R packages. The first is to add the "mro" channel to your :doc:`.condarc configuration file<config>` above the "r" channel, and then use ``conda install r`` and use conda to install other packages. The second is to specify the "mro" channel on the command line each time you use the conda install command: ``conda install -c mro r``
+
+If you use OS X, find the R directory and set the R_HOME environment variable to its path. Look in your home directory, then in your Anaconda or Miniconda directory, then in the environments directory, then in the directory for your current environment, and then in the "lib" directory. For example, if you use Anaconda and your current environment is named my_r_env, you might use this command: ``export R_HOME=~/Anaconda/envs/my_r_env/lib/R``
 
 In addition to installing R packages from conda channels, it is possible to install R packages from the Comprehensive R Archive Network (CRAN) or the Microsoft R Application Network (MRAN). These R packages will install into the currently active conda environment. MRO includes the `checkpoint package <https://github.com/RevolutionAnalytics/checkpoint/>`_, which installs from MRAN and is designed to offer enhanced `reproducibility <https://mran.revolutionanalytics.com/documents/rro/reproducibility/>`_.
 
@@ -15,7 +17,7 @@ Each conda environment may have packages installed from the channel "r" or the c
 Installing the Intel Math Kernel Library (MKL) with Microsoft R Open
 ====================================================================
 
-The Intel Math Kernel Library (MKL) extensions are also available for MRO on Windows and Linux. Just `download the MKL package for your platform <https://mran.revolutionanalytics.com/download/>`_ and install it according to the instructions below.
+The Intel Math Kernel Library (MKL) extensions are also available for MRO on Windows and Linux, while the Accelerate library is used instead on OS X. Just `download the MKL package for your platform <https://mran.revolutionanalytics.com/download/>`_ and install it according to the instructions below.
 
 NOTE: By using our install process, we assume that you have already agreed to the `MKL license <https://mran.revolutionanalytics.com/assets/text/mkl-eula.txt>`_. Proceeding further is an implicit agreement to said license.
 


### PR DESCRIPTION
add OSX info on MRO page. not yet supported in product, but we're
working on it, so don't merge this yet or close it.