### PR TITLE
correct linux versions

### DIFF
--- a/docs/source/mro.rst
+++ b/docs/source/mro.rst
@@ -2,7 +2,7 @@
 Using Microsoft R Open
 ======================
 
-You can install `Microsoft R Open (MRO) <https://mran.revolutionanalytics.com/download/mro-for-mrs/>`_ with conda on 64-bit Windows, 64-bit OS X, and 64-bit Linux, from the Anaconda.org channel "mro". The supported Windows versions are Windows® 7.0 (SP1), 8.1, 10, and Windows Server® 2008 R2 (SP1) and 2012, the supported OS X versions are Mavericks (10.9), Yosemite (10.10), and El Capitan (10.11), and the supported Linux versions are Ubuntu 12.04, 14.04, and 15.04, CentOS and Red Hat Enterprise Linux 5.8, 6.5, and 7.1, SUSE Linux Enterprise Server 10 and 11, and OpenSUSE 13.1.
+You can install `Microsoft R Open (MRO) <https://mran.revolutionanalytics.com/download/mro-for-mrs/>`_ with conda on 64-bit Windows, 64-bit OS X, and 64-bit Linux, from the Anaconda.org channel "mro". The supported Windows versions are Windows® 7.0 (SP1), 8.1, 10, and Windows Server® 2008 R2 (SP1) and 2012, and the supported OS X versions are Mavericks (10.9), Yosemite (10.10), and El Capitan (10.11). Microsoft R Open is supported on all the same versions of Linux as Anaconda, including CentOS, Red Hat Enterprise Linux, Debian, and Ubuntu.
 
 There are two ways to install MRO and other R packages. The first is to add the "mro" channel to your :doc:`.condarc configuration file<config>` above the "r" channel, and then use ``conda install r`` and use conda to install other packages. The second is to specify the "mro" channel on the command line each time you use the conda install command: ``conda install -c mro r``
 
@@ -48,9 +48,6 @@ MKL installation on Linux
 -------------------------
 
 1. Download and extract the proper MKL package to a temporary folder, which we will call $REVOMATH .
-
-   NOTE: You must select the correct MKL package for your Linux distribution.
-
 2. Determine where R is located. The path will have the form of ``/path/to/anaconda/envs/<r environment>`` , which we will call $PREFIX . Ensure that you have write permissions to $PREFIX.
 3. Make backups of ``$PREFIX/lib/R/lib/libRblas.so`` and ``$PREFIX/lib/R/lib/libRlapack.so`` .
 4. Copy all the .so files from ``$REVOMATH/mkl/libs/*.so`` to ``$PREFIX/lib/R/lib`` . (This may prompt you to overwrite libRblas.so and libRlapack.so.)


### PR DESCRIPTION
correct linux versions: we build mro packages from source, so all
the same versions of linux that work with other continuum packages
should work here. the MKL packages on the site are all the same
except for the one for SLES 10, which we don't support, so it isn't
actually important that they download the correct one for their
version of Linux, so removed that note.