### PR TITLE
meta-yaml: Fixed description of about/license_file field.

### DIFF
--- a/docs/source/building/meta-yaml.rst
+++ b/docs/source/building/meta-yaml.rst
@@ -441,7 +441,7 @@ Identifying information about the package. Displays in Anaconda.org channel.
 License file
 ~~~~~~~~~~~~
 
-A file containing the software license can be added to the package metadata.  Please note that many licenses require the license statement to be distributed with the package.  As a convenience, a value of True will use the first file found by looking in the source root directory for LICENSE, LICENSE.txt, license, or license.txt, in that order.  A value of False (the default) indicates no license file will be included in the package metadata.  The filename is relative to the source directory.
+A file containing the software license can be added to the package metadata.  Please note that many licenses require the license statement to be distributed with the package.  The filename is relative to the source directory.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
See [conda_build/CHANGELOG.txt, v1.19.0][1]

[1]: https://github.com/conda/conda-build/blob/38e688c67023a9203e753db4b6c7ad1c536066fc/CHANGELOG.txt#L25-L26