### PR TITLE
deprecate unxutils

### DIFF
--- a/docs/source/build_tutorials/pkgs.rst
+++ b/docs/source/build_tutorials/pkgs.rst
@@ -28,15 +28,7 @@ Building a simple conda package can be done in two steps, with two optional step
 You should already have conda and conda-build by downloading and installing Miniconda or Anaconda.
 Please follow the Quick Install instructions.
 
-**Windows users only:*** install unxutils.
-
-At the command prompt, enter the following:
-
-.. code-block:: bash
-
-    conda install unxutils
-
-**All users:** next, install conda-build:
+Install conda-build:
 
 .. code-block:: bash
 


### PR DESCRIPTION
@msarahan in https://github.com/conda/conda-build/issues/851 says unxutils is deprecated and conda-build on windows already depends on the patch package, which provides the functionality unxutils formerly provided.