### PR TITLE
DOC: Stop setting values for undefined variables listed in `script_env`

### DIFF
--- a/docs/source/building/environment-vars.rst
+++ b/docs/source/building/environment-vars.rst
@@ -200,8 +200,8 @@ additional environment variables by adding them to ``meta.yaml``:
         - LD_LIBRARY_PATH # [linux]
         - DYLD_LIBRARY_PATH # [osx]
 
-If an inherited variable was missing from your shell environment, it will be 
-assigned the value ``<UNDEFINED>``.
+If an inherited variable was missing from your shell environment, it will remain 
+unassigned, but a warning will be issued noting that it has no value assigned.
 
 NOTE: Inheriting environment variables like this can make it difficult for others
 to reproduce binaries from source with your recipe. This feature should be 


### PR DESCRIPTION
Documents the changed behavior with undefined `script_env` variables. Previously, undefined environment variables would be set to `<UNDEFINED>`. However, this caused a number of problems including their use in `jinja`. As the behavior was a bit unexpected and caused problems, this was changed. Here we update the docs to reflect that change.

xref: https://github.com/conda/conda-build/pull/763

PS: I tried to make this change using GitHub's web editing interface. We'll see how this goes.