### PR TITLE
build jinja fix; source clarification

### DIFF
--- a/docs/source/building/environment-vars.rst
+++ b/docs/source/building/environment-vars.rst
@@ -135,7 +135,8 @@ On Linux, we have:
 Git Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When the source is a git repository, the following variables are defined:
+When the source is a git repository, specifying the source either with ``git_url``
+or ``path``, the following variables are defined:
 
 .. list-table::
 
@@ -163,14 +164,14 @@ so the ``git_url`` is ``../``:
 
      package:
        name: mypkg
-       version: {{ environ.get('GIT_DESCRIBE_TAG', '') }}
+       version: {{ GIT_DESCRIBE_TAG }}
 
      build:
-       number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+       number: {{ GIT_DESCRIBE_NUMBER }}
 
        # Note that this will override the default build string with the Python
        # and NumPy versions
-       string: {{ environ.get('GIT_BUILD_STR', '') }}
+       string: {{ GIT_BUILD_STR }}
 
      source:
        git_url: ../
@@ -182,6 +183,11 @@ Note that build.sh is run with ``bash -x -e`` (the ``-x`` makes it echo each
 command that is run, and the ``-e`` makes it exit whenever a command in the
 script returns nonzero exit status).  You can revert this in the script if you
 need to by using the ``set`` command.
+
+The only practical difference between ``git_url`` and ``path`` as source arguments
+is that git_url is a clone of a repository and path is copy of the repository.
+Using path will allow you to build packages with unstaged/uncommited changes in
+working directory. git_url can only build up to the latest commit.
 
 .. _inherited-env-vars:
 


### PR DESCRIPTION
I think as of https://github.com/conda/conda-build/pull/667, we have simplified the jinja environment variable usage.  Unfortunately, this means a breakage of old recipes.

The crux of this issue is that the new approach takes a two-pass jinja approach:
  - once to fill in anything like version numbers, so that source code can be downloaded
  - once to fill in anything else that source code may define (git variables, for example)

The old syntax of ```environ.get("varname")``` is unfortunately perfectly evaluable on the first pass, and so rather than waiting for the second pass where the variable does exist, the template placeholder is replaced with None on the first pass.

This fixes the docs for the new way, but we should probably also find a way to alert people to this breakage, and possibly offer automatic recognition/conversion tools for conda build.

cc @stuarteberg 