### PR TITLE
Document `add_pip_as_python_depedency` for `.condarc`

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -108,6 +108,17 @@ environment. The default is ``True``.
   changeps1: False
 
 
+Add PIP as Python Dependency (add_pip_as_python_depedency)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Add pip and setuptools as dependencies of python. This ensures pip and setuptools
+will always be installed any time python is installed. The default is ``True``.
+
+.. code-block:: yaml
+
+  add_pip_as_python_dependency: False
+
+
 Use PIP (use_pip)
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This documents the addition of `add_pip_as_python_depedency` as a parameter in `.condarc`, which was proposed in this PR ( https://github.com/conda/conda/pull/1577 ) by @ilanschnell and later was accepted in this merge commit ( https://github.com/conda/conda/commit/d86652767dc6f5aee3b14f8b3cb5e34d1448d9de ). This first appeared in the 3.17.0 and has been present since.