### PR TITLE
Note `wheel` is skipped when `add_pip_as_python_depedency` is disabled

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -111,8 +111,9 @@ environment. The default is ``True``.
 Add PIP as Python Dependency (add_pip_as_python_depedency)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Add pip and setuptools as dependencies of python. This ensures pip and setuptools
-will always be installed any time python is installed. The default is ``True``.
+Add pip, wheel and setuptools as dependencies of python. This ensures pip, wheel
+and setuptools will always be installed any time python is installed.
+The default is ``True``.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Follow-up on PR ( https://github.com/conda/conda-docs/pull/276 ).

Failed to note that `wheel` will also not be installed when `add_pip_as_python_depedency` is disabled.