### PR TITLE
Release 1.20.3 fixes

### DIFF
--- a/docs/source/building/meta-yaml.rst
+++ b/docs/source/building/meta-yaml.rst
@@ -213,7 +213,7 @@ A list of globs for files that should always be copied and never soft linked or 
 
   build:
     no_link:
-      - bin/*.py # Don't link any .py files in bin/
+      - bin/\*.py # Don't link any .py files in bin/
 
 Script
 ~~~~~~
@@ -311,6 +311,18 @@ Default is False.
 
   build:
     skip: True  # [not win]
+
+Architecture independent packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The conda build system allows you to specify "no architecture" when building a package, thus making it compatible
+with all platforms and architectures. Noarch packages can be installed on any platform.
+
+
+.. code-block:: yaml
+
+     build:
+       noarch_python: True
 
 Requirements section
 --------------------

--- a/docs/source/building/meta-yaml.rst
+++ b/docs/source/building/meta-yaml.rst
@@ -64,13 +64,11 @@ Source from tarball
 .. code-block:: yaml
 
   source:
-    fn: bsdiff-1.1.14.tar.gz
     url: https://pypi.python.org/packages/source/b/bsdiff4/bsdiff4-1.1.4.tar.gz
     md5: 29f6089290505fc1a852e176bd276c43
     sha1: f0a2c9a30073449cfb7d171c57552f3109d93894
     sha256: 5a022ff4c1d1de87232b1c70bde50afbb98212fd246be4a867d8737173cf1f8f
 
-NOTE: If you use ``url`` above, then ``fn`` is also required.
 
 Source from git
 ~~~~~~~~~~~~~~~

--- a/docs/source/building/recipe.rst
+++ b/docs/source/building/recipe.rst
@@ -12,7 +12,7 @@ is a flat directory holding metadata and the scripts needed to build the package
 The conda package is then built from the conda recipe using the ``conda build`` command.
 
 Conda packages can be built from a variety of source code projects, most notably Python.
-Please refer to the `Setuptools documentation <https://setuptools.readthedocs.io/en/latest/`_
+Please refer to the `Setuptools documentation <https://setuptools.readthedocs.io/en/latest/>`_
 for help packing a Python project.
 
 TIP: If you are new to building packages with conda, we recommend taking our series 

--- a/docs/source/building/recipe.rst
+++ b/docs/source/building/recipe.rst
@@ -11,6 +11,10 @@ Building a conda package with conda build involves creating a conda recipe. The 
 is a flat directory holding metadata and the scripts needed to build the package. 
 The conda package is then built from the conda recipe using the ``conda build`` command.
 
+Conda packages can be built from a variety of source code projects, most notably Python.
+Please refer to the `Setuptools documentation <https://setuptools.readthedocs.io/en/latest/`_
+for help packing a Python project.
+
 TIP: If you are new to building packages with conda, we recommend taking our series 
 of three :doc:`build tutorials </build_tutorials>`.
 

--- a/docs/source/building/recipe.rst
+++ b/docs/source/building/recipe.rst
@@ -29,6 +29,21 @@ Please follow the :doc:`Quick install</install/quick>` instructions.
 OPTIONAL: If you wish to upload packages to Anaconda.org , an `Anaconda.org <http://anaconda.org>`_ 
 account and client are required.
 
+Update conda build
+~~~~~~~~~~~~~~~~~~
+
+It is important to keep your version of ``conda build`` up to date to take advantage of
+bug fixes and new features.
+
+**All platforms:** Upgrade conda-build:
+
+.. code-block:: bash
+
+  conda update conda
+  conda update conda-build
+
+Release notes are available on the `conda-build Github page. <https://github.com/conda/conda-build/releases>`_
+
 Conda recipe files overview
 ===========================
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Conda'
-copyright = u'2015, Continuum Analytics'
+copyright = u'2016, Continuum Analytics'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/help/conda-pip-virtualenv-translator.html
+++ b/docs/source/help/conda-pip-virtualenv-translator.html
@@ -126,7 +126,7 @@ environment manager. Conda is both.</p>
 
   <div role="contentinfo">
     <p>
-        &copy; Copyright 2015, Continuum Analytics.
+        &copy; Copyright 2016, Continuum Analytics.
     </p>
   </div>
 

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -4,7 +4,7 @@ Conda license
 
 Except where noted below, conda is released under the following terms:
 
-(c) 2015 Continuum Analytics, Inc. / http://continuum.io
+(c) 2016 Continuum Analytics, Inc. / http://continuum.io
 All Rights Reserved
 
 Redistribution and use in source and binary forms, with or without

--- a/web/source/conf.py
+++ b/web/source/conf.py
@@ -45,7 +45,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Conda'
-copyright = '2014, Continuum Analytics'
+copyright = '2016, Continuum Analytics'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Fixes:
* `fn` is now optional
* added `noarch`
* added `conda update conda-build`
* included link to setuptools documentation
* updated copyright to 2016