### PR TITLE
Fix Windows silent install commandline

### DIFF
--- a/docs/source/help/silent.rst
+++ b/docs/source/help/silent.rst
@@ -17,8 +17,8 @@ is up to date with a simple:
 Windows
 ~~~~~~~
 
-The Windows installer of Miniconda can be run in silent mode using the ``/S`` argument. The following optional arguments
-are supported:
+The Windows installer of Miniconda can be run in silent mode using
+the ``/S`` argument. The following optional arguments are supported:
 
 - ``/InstallationType=[JustMe|AllUsers]``, default: ``JustMe``
 - ``/AddToPath=[0|1]``, default: ``1``
@@ -26,10 +26,11 @@ are supported:
 - ``/S``
 - ``/D=<installation path>``
 
-All arguments are case-sensitive. The installation path must be the last argument and should **NOT** be wrapped in
-quotation marks.
+All arguments are case-sensitive. The installation path must be the last
+argument and should **NOT** be wrapped in quotation marks.
 
-The following command installs Miniconda for the current user without registering Python as the system's default:
+The following command installs Miniconda for the current user without
+registering Python as the system's default:
 
 .. code-block:: bat
 
@@ -56,4 +57,3 @@ A complete example:
     wget http://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh -O ~/miniconda.sh
     bash ~/miniconda.sh -b -p $HOME/miniconda
     export PATH="$HOME/miniconda/bin:$PATH"
-

--- a/docs/source/help/silent.rst
+++ b/docs/source/help/silent.rst
@@ -29,12 +29,11 @@ are supported:
 All arguments are case-sensitive. The installation path must be the last argument and should **NOT** be wrapped in
 quotation marks.
 
-The following command installs Miniconda for all users without registering Python as the system's default:
+The following command installs Miniconda for the current user without registering Python as the system's default:
 
 .. code-block:: bat
 
-    Miniconda2-latest-Windows-x86_64.exe /InstallationType=AllUsers /RegisterPython=0 \
-        /S /D=C:\Program Files\Miniconda3
+    start /wait "" Miniconda4-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /D=%UserProfile%\Miniconda3
 
 
 Linux and OS X


### PR DESCRIPTION
  1. JustMe is preferable.
  2. Blocking instead of immediately returning to the prompt.
  3. Removed the line continuation since it's not correct for cmd.exe.
  4. Install to %UserProfile% not C:\Program Files (x86)

The line is quite long, and we could split it with '^' but Windows asks "More?" if you do that, and I think that's quite ugly and people may think that the installer is asking it.

See what you think, I'm happy to make changes.