### PR TITLE
Document the CONDA_PREFIX environment variable

### DIFF
--- a/docs/source/building/environment-vars.rst
+++ b/docs/source/building/environment-vars.rst
@@ -221,6 +221,11 @@ Environment variables that affect the build process
    * - ``CONDA_NPY``
      - This is the NumPy version used to build the package, such as ``19``,
        ``110``, or ``111``.
+   * - ``CONDA_PREFIX``
+     - This is the path to the conda environment used to build the package,
+       e.g. ``/path/to/conda/env``. Useful to pass as the environment prefix
+       parameter to various conda tools, usually labeled
+       ``-p`` or ``--prefix``.
 
 .. _build-features:
 


### PR DESCRIPTION
The CONDA_PREFIX variable can now be used instead of relying on the `_test` environment from previous versions of conda.