### PR TITLE
Mark dot as allowed character in package name

### DIFF
--- a/docs/source/building/pkg-name-conv.rst
+++ b/docs/source/building/pkg-name-conv.rst
@@ -14,7 +14,7 @@ conda employs the following naming conventions with respect to packages:
 **package name**
     The name of a package, without any reference to a particular version.
     Conda package names are normalized, and may contain only lowercase alpha
-    characters, numeric digits, underscores, or hyphens.  In usage
+    characters, numeric digits, underscores, hyphens, or dots.  In usage
     documentation, these will be referred to by `package_name`.
 
 .. _package_version:


### PR DESCRIPTION
Conda does not complain if dots are used as a part of the package name, yet this is not mentioned in the documentation.

Packages that have dots in name are already present in default channel (zope.deprecation, zope.interface, ...) as well as on conda-forge (bob.ap, bob.blit, bob.core, ...). There are also many python packages on pypi that include dot in the name that might be used in conda recipes in the future and would benefit if the same name could be used for both packages.