### PR TITLE
corrected update_dependencies which defaults to True

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -276,11 +276,11 @@ dependencies to the latest versions.
 
 If you prefer to only update the packages given explicitly at the command line
 and avoid updating existing installed packages as much as possible, you can
-set ``update_dependencies`` to ``True``.
+set ``update_dependencies`` to ``False``.
 
 .. code-block:: yaml
 
-   update_dependencies: True
+   update_dependencies: False
 
 Note that conda will still ensure that dependency specifications are
 satisfied, so some dependencies may still be updated, or, conversely, this may


### PR DESCRIPTION
Minor change. If user wants to disable auto updating dependencies, then the flag should read `False` instead of `True`
Link [http://conda.pydata.org/docs/config.html#disable-updating-of-dependencies-update-dependencies](http://conda.pydata.org/docs/config.html#disable-updating-of-dependencies-update-dependencies)