### PR TITLE
DOC: swap order of py2 and py3 in download docs faq

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -49,8 +49,8 @@ Whether you are on Linux, OS X or Windows, there is an installer to make it easy
 What version of Python should I choose?
 ---------------------------------------
 
-* The latest version of Python 2 is 2.7, and that is included with Anaconda and Miniconda. 
 * The newest stable version of Python is 3.5, and that is included with Anaconda3 and Miniconda3. 
+* The last version of legacy Python 2 is 2.7, and that is included with Anaconda and Miniconda. 
 * You can easily set up additional versions of Python such as 3.4 by downloading any version and creating a new environment with just a few clicks. (See our :doc:`test-drive`.)
 
 What about cryptographic hash verification?

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -50,7 +50,7 @@ What version of Python should I choose?
 ---------------------------------------
 
 * The newest stable version of Python is 3.5, and that is included with Anaconda3 and Miniconda3. 
-* The last version of legacy Python 2 is 2.7, and that is included with Anaconda and Miniconda. 
+* The last version of Python 2 is 2.7, and that is included with Anaconda and Miniconda. 
 * You can easily set up additional versions of Python such as 3.4 by downloading any version and creating a new environment with just a few clicks. (See our :doc:`test-drive`.)
 
 What about cryptographic hash verification?


### PR DESCRIPTION
A follow-up of https://github.com/conda/conda-docs/pull/386 . Also changed "latest" to "last" and "Python 2" with "legacy Python 2", consistent with the introduction of the same page, which says: 

>  All can be downloaded with legacy Python 2.7 or current Python 3. (...)

> TIP: If you are unsure, we recommend the most recent version of Anaconda3 - that automatically includes Python 3.5, the most recent version of Python. If you are on Windows or OS X, we recommend you also choose the version with GUI installer.