### PR TITLE
document split package usage in conda-build

### DIFF
--- a/docs/source/building/meta-yaml.rst
+++ b/docs/source/building/meta-yaml.rst
@@ -577,7 +577,7 @@ different package output type. Format is a list of mappings. Build strings for
 subpackages are determined by their runtime dependencies. This support was added
 in conda-build 2.1.0.
 
-.. code-block:: yaml
+.. code-block:: none
 
    outputs:
      - name: some-subpackage
@@ -603,7 +603,7 @@ Explicit file lists support glob expressions. Directory names are also
 supported, and will recursively include contents.
 
 
-.. code-block:: yaml
+.. code-block:: none
 
    outputs:
      - name: subpackage-name
@@ -618,7 +618,7 @@ Scripts that create or move files into the build prefix can be any kind of
 script. Known script types need only specify the script name. Currently the list
 of recognized extensions is ``py``, ``bat``, ``ps1``, ``sh``
 
-.. code-block:: yaml
+.. code-block:: none
 
    outputs:
      - name: subpackage-name
@@ -628,7 +628,7 @@ of recognized extensions is ``py``, ``bat``, ``ps1``, ``sh``
 The interpreter command must be specified if the file extension is not
 "recognized."
 
-.. code-block:: yaml
+.. code-block:: none
 
    outputs:
      - name: subpackage-name
@@ -654,7 +654,7 @@ supported, because subpackages are created after the build phase is complete. If
 you need a tool to accomplish subpackaging, put it in the top-level package
 requirements/build section.
 
-.. code-block:: yaml
+.. code-block:: none
 
    outputs:
      - name: subpackage-name
@@ -665,7 +665,7 @@ requirements/build section.
 Subpackage dependencies propagate to the top-level package if and only if the
 subpackage is listed as a requirement.
 
-.. code-block:: yaml
+.. code-block:: none
 
    requirements:
      run:
@@ -691,7 +691,7 @@ matches the top-level package/name, then conda-build will create a metapackage
 for you. This metapackage will have runtime requirements drawn from its
 dependency subpackages, for the sake of accurate build strings.
 
-.. code-block:: yaml
+.. code-block:: none
 
    package:
      name: subpackage-example
@@ -728,7 +728,7 @@ test section. These files support the same formats as the top-level run_test.*
 scripts: ``.py``, ``.pl``, ``.bat``, ``.sh``. These may be extended to support
 other script types in the future.
 
-.. code-block:: yaml
+.. code-block:: none
 
    outputs:
      - name: subpackage-name
@@ -739,7 +739,7 @@ other script types in the future.
 The run_test.* scripts apply only to the top-level package, by default. To apply
 them also to subpackages, they can be explicitly listed in the script section:
 
-.. code-block:: yaml
+.. code-block:: none
 
    outputs:
      - name: subpackage-name
@@ -751,7 +751,7 @@ Test requirements for subpackages are not supported. Instead, subpackage tests
 install their runtime requirements (but not the run requirements for the
 top-level package) and the test-time requirements of the top-level package.
 
-.. code-block:: yaml
+.. code-block:: none
 
    requirements:
      run:
@@ -781,7 +781,7 @@ that support includes only wheels. RPMs, .deb files, and others may come as
 demand appears.  If type is not specified, the default value is ``conda``.
 
 
-.. code-block:: yaml
+.. code-block:: none
 
    requirements:
      build:
@@ -797,7 +797,7 @@ requirements/build section in order to build wheels.
 When specifying type, the name field is optional, and defaults to the
 package/name field for the top-level recipe.
 
-.. code-block:: yaml
+.. code-block:: none
 
    requirements:
      build:

--- a/docs/source/building/meta-yaml.rst
+++ b/docs/source/building/meta-yaml.rst
@@ -572,10 +572,10 @@ NOTE: Python or Perl .py/.pl scripts are only valid as part of Python/Perl packa
 Outputs section
 ---------------
 
-Explicitly specify packaging steps. Supports multiple outputs, as well as
-different package output type. Format is a list of mappings. Build strings for
-subpackages are determined by their runtime dependencies. This support was added
-in conda-build 2.1.0.
+The outputs section is used to explicitly specify packaging steps. It supports
+multiple outputs, as well as different package output types. The format is a
+list of mappings. Build strings for subpackages are determined by their runtime
+dependencies. This support was added in conda-build 2.1.0.
 
 .. code-block:: none
 
@@ -584,7 +584,7 @@ in conda-build 2.1.0.
      - name: some-other-subpackage
 
 
-NOTE: if any output is specified in the outputs section, the default packaging
+NOTE: If any output is specified in the outputs section, the default packaging
 behavior of conda-build is bypassed. In other words, if any subpackage is
 specified, then you will not get the normal top-level build for this recipe
 without explicitly defining a subpackage for it. This is an alternative to the
@@ -595,8 +595,8 @@ section below for more information.
 Specifying files to include in output
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Files to be included in the package can be specified one of two ways: explicit
-file lists, or scripts that move files into the build prefix.
+Files to be included in the package can be specified in either of two ways:
+explicit file lists, or scripts that move files into the build prefix.
 
 Explicit file lists are relative paths from the root of the build prefix.
 Explicit file lists support glob expressions. Directory names are also
@@ -616,7 +616,7 @@ supported, and will recursively include contents.
 
 Scripts that create or move files into the build prefix can be any kind of
 script. Known script types need only specify the script name. Currently the list
-of recognized extensions is ``py``, ``bat``, ``ps1``, ``sh``
+of recognized extensions is ``py``, ``bat``, ``ps1``, and ``sh``.
 
 .. code-block:: none
 
@@ -636,9 +636,9 @@ The interpreter command must be specified if the file extension is not
        script_interpreter: program plus arguments to run script
 
 
- For scripts that move or create files, a fresh copy of the working directory is
- provided at the start of each script execution. Results between scripts are
- thus independent of one another.
+For scripts that move or create files, a fresh copy of the working directory is
+provided at the start of each script execution. This ensures results between
+scripts are independent of one another.
 
 Note that for either the file list or the script approach, having more than one
 package contain a given file is not explicitly forbidden, but may prevent
@@ -809,7 +809,7 @@ package/name field for the top-level recipe.
 Conda-build currently only knows how to test conda packages. Conda-build does
 support using Twine to upload packages to PyPI. See the conda-build help output
 for the list of arguments accepted that will be passed through to Twine. Note
-that you must install twine (via pip) in order for this to work.
+that you must use pip to install Twine in order for this to work.
 
 
 .. _about:


### PR DESCRIPTION
This is a new feature, to be added in the coming conda-build 2.1.0 release.