### PR TITLE
Add note for Windows users re trailing slash

### DIFF
--- a/docs/source/install/central.rst
+++ b/docs/source/install/central.rst
@@ -109,6 +109,10 @@ Alias for non-url channels used with the -c or --channel flag. The default is ``
 .. code-block:: yaml
 
   channel_alias: https://your.repo/conda
+  
+NOTE: For Windows users, the slash (/) at the end of a URL is required. 
+Example https://your.repo/conda/
+
 
 Disallow installation of specific packages (disallow)
 -----------------------------------------------------


### PR DESCRIPTION
trailing slash is required.