### PR TITLE
Fix typo in bdist_conda.rst

### DIFF
--- a/docs/source/bdist_conda.rst
+++ b/docs/source/bdist_conda.rst
@@ -142,7 +142,7 @@ Set the build number. Defaults to the ``conda_buildnum`` passed to ``setup()``, 
 Notes
 =====
 
-- ``bdist_conda`` must be installed into a root conda environment, as it imports ``conda`` and ``conda_build``. It is included as part of the ``conda build`` package.
+- ``bdist_conda`` must be installed into a root conda environment, as it imports ``conda`` and ``conda_build``. It is included as part of the ``conda-build`` package.
 
 - All metadata is gathered from the standard metadata from the ``setup()`` function. Metadata that are not directly supported by ``setup()`` can be added using one of the options specified below.
 


### PR DESCRIPTION
This had me confused for a minute. The package name is clearly "conda-build" and this is a typo, no?
```
$ conda install "conda build"
CondaValueError: Value error: invalid package specification: conda build
```