### PR TITLE
Fix confusing typo

### DIFF
--- a/docs/source/py2or3.rst
+++ b/docs/source/py2or3.rst
@@ -75,7 +75,7 @@ the default is 3.6.
 Create a Python 3.6 environment
 ````````````````````````````````
 
-To create a new environment with a different version of Python, use the ``conda create`` command. In this example, we'll make the new environment for Python 3.5:
+To create a new environment with a different version of Python, use the ``conda create`` command. In this example, we'll make the new environment for Python 3.6:
 
 .. code-block:: bash
 


### PR DESCRIPTION
I think there's a mistake in the description of one of the examples:

- The section is "Create a Python 3.6 environment", 
- The code block is conda create (. . .) python3.6 **

However, the description is "In this example, we’ll (. . .) for **Python 3.5**" 

I'm assuming this description should be for **Python 3.6**, because two of the three mentions of a python version in this example are 3.6