### PR TITLE
use setup.py install command which prevents eggs

### DIFF
--- a/docs/source/user-guide/tasks/build-packages/define-metadata.rst
+++ b/docs/source/user-guide/tasks/build-packages/define-metadata.rst
@@ -338,7 +338,7 @@ for different platforms.
 .. code-block:: yaml
 
    build:
-     script: python setup.py install
+     script: python setup.py install --single-version-externally-managed --record=record.txt
 
 RPATHs
 ------

--- a/docs/source/user-guide/tutorials/bld.bat
+++ b/docs/source/user-guide/tutorials/bld.bat
@@ -1,2 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1

--- a/docs/source/user-guide/tutorials/build-pkgs.rst
+++ b/docs/source/user-guide/tutorials/build-pkgs.rst
@@ -129,7 +129,7 @@ for their architecture.
 
    .. code-block:: bash
 
-       "%PYTHON%" setup.py install
+       "%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
        if errorlevel 1 exit 1
 
    NOTE: In ``bld.bat``, the best practice is to to add
@@ -144,7 +144,7 @@ for their architecture.
 
    .. code-block:: bash
 
-       $PYTHON setup.py install     # Python command to install the script.
+       $PYTHON setup.py install --single-version-externally-managed --record=record.txt  # Python command to install the script.
 
 
 #. Save your new ``build.sh`` file to the same directory where you

--- a/docs/source/user-guide/tutorials/build.sh
+++ b/docs/source/user-guide/tutorials/build.sh
@@ -1,1 +1,1 @@
-$PYTHON setup.py install 
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/docs/source/user-guide/tutorials/rodeo/build.sh
+++ b/docs/source/user-guide/tutorials/rodeo/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt
 
 if [ `uname` == Darwin ]
 then


### PR DESCRIPTION
When giving example of install scripts for package which use setuptools use the
command:

python setup.py install --single-version-externally-managed --record=record.txt

This command prevents egg's from being created.