### PR TITLE
warn about script_env being different when splitting build and test

### DIFF
--- a/docs/source/user-guide/tasks/build-packages/define-metadata.rst
+++ b/docs/source/user-guide/tasks/build-packages/define-metadata.rst
@@ -586,6 +586,16 @@ seen by the conda build process itself, a UserWarning is
 emitted during the build process and the variable remains
 undefined.
 
+NOTE: Inheriting environment variables can make it difficult for
+others to reproduce binaries from source with your recipe. Use
+this feature with caution or avoid it.
+
+NOTE: If you split your build and test phases with ``--no-test`` and ``--test``,
+you need to ensure that the environment variables present at build time and test
+time match. If you do not, the package hashes may use different values, and your
+package may not be testable, because the hashes will differ.
+
+
 .. _run_exports:
 
 Pin downstream

--- a/docs/source/user-guide/tasks/build-packages/environment-variables.rst
+++ b/docs/source/user-guide/tasks/build-packages/environment-variables.rst
@@ -276,6 +276,11 @@ NOTE: Inheriting environment variables can make it difficult for
 others to reproduce binaries from source with your recipe. Use
 this feature with caution or avoid it.
 
+NOTE: If you split your build and test phases with ``--no-test`` and ``--test``,
+you need to ensure that the environment variables present at build time and test
+time match. If you do not, the package hashes may use different values, and your
+package may not be testable, because the hashes will differ.
+
 
 .. _build-envs:
 


### PR DESCRIPTION
discovered by @stuartarchibald in https://github.com/conda/conda-build/issues/2498 and https://github.com/conda/conda-build/issues/2499