### PR TITLE
Update the default_channels example

### DIFF
--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -157,11 +157,10 @@ useful for air gap and enterprise installations:
 
 .. code-block:: yaml
 
-  channels:
+  default_channels:
     - <anaconda_dot_org_username>
     - http://some.custom/channel
     - file:///some/local/directory
-    - defaults
 
 Update conda automatically (auto_update_conda)
 ----------------------------------------------


### PR DESCRIPTION
Use the `default_channels` name -- instead of `channels` -- and drop `defaults` since that doesn't make sense when that's what you're redefining.