### PR TITLE
wip: replace pyinstrument in tutorials with click

### DIFF
--- a/docs/source/user-guide/tutorials/build-pkgs-skeleton.rst
+++ b/docs/source/user-guide/tutorials/build-pkgs-skeleton.rst
@@ -52,33 +52,32 @@ In this section you are going to use conda skeleton to generate a
 conda recipe, which informs conda build about where the source
 files are located and how to build and install the package.
 
-You'll be working with a package named Pyinstrument_ that is
-hosted on PyPI. Pyinstrument is a Python statistical profiler
-that records the whole call stack once each millisecond, so
-programmers can see which parts of their code are slowest and how
-to make them faster.
+You'll be working with a package named Click_ that is hosted on PyPI. Click is a
+tool for exposing python functions to create command line interfaces.
 
-.. _Pyinstrument: https://github.com/joerick/pyinstrument
+.. _Click: https://github.com/pallets/click
 
 First, in your user home directory, run the ``conda skeleton``
 command:
 
 .. code-block:: bash
 
-    conda skeleton pypi pyinstrument
+    conda skeleton pypi click
 
 The two arguments to ``conda skeleton`` are the hosting location,
 in this case ``pypi``, and the name of the package.
 
-This creates a directory named ``Pyinstrument`` and creates three
-skeleton files in that directory: ``meta.yaml``, ``build.sh``,
-and ``bld.bat``. Use the ``ls`` command on OS X or Linux or the
-``dir`` command on Windows to verify that these files have been
-created. The three files have been populated with information
-from the PyPI metadata and in most cases will not need to be
-edited.
+This creates a directory named ``click`` and creates one
+skeleton file in that directory: ``meta.yaml``. Many other files can be added
+there as necessary, such as ``build.sh``, and ``bld.bat``, test scripts, or
+anything else you need to build your software. For simple, pure-python recipes,
+these extra files are unnecessary, and the build/script section in the meta.yaml
+is sufficient. Use the ``ls`` command on OS X or Linux or the ``dir`` command on
+Windows to verify that this file has been created. The meta.yaml file has been
+populated with information from the PyPI metadata and in many cases will not
+need to be edited.
 
-These three files are collectively referred to as the "conda
+Files in the folder with meta.yaml are collectively referred to as the "conda
 build recipe":
 
 * ``meta.yaml``---Contains all the metadata in the recipe. Only
@@ -94,7 +93,7 @@ build to create the package:
 
 .. code-block:: bash
 
-    conda-build pyinstrument
+    conda-build click
 
 When conda build is finished, it displays the exact path and
 filename of the conda package. See :ref:`troubleshooting` if the
@@ -104,20 +103,20 @@ Windows example file path:
 
 .. code-block:: text
 
-    C:\Users\jsmith\Miniconda\conda-bld\win-64\pyinstrument-0.13.1-py27_0.tar.bz2
+    C:\Users\jsmith\Miniconda\conda-bld\win-64\click-6.7-py27_0.tar.bz2
 
 OS X example file path:
 
 .. code-block:: text
 
-    /Users/jsmith/miniconda/conda-bld/osx-64/pyinstrument-0.13.1-py27_0.tar.bz2
+    /Users/jsmith/miniconda/conda-bld/osx-64/click-6.7-py27_0.tar.bz2
 
 
 Linux example file path:
 
 .. code-block:: text
 
-    /home/jsmith/miniconda/conda-bld/linux-64/pyinstrument-0.13.1-py27_0.tar.bz2
+    /home/jsmith/miniconda/conda-bld/linux-64/click-6.7-py27_0.tar.bz2
 
 
 NOTE: Your path and filename will vary depending on your
@@ -129,15 +128,15 @@ environment by using the use-local flag:
 
 .. code-block:: bash
 
-    conda install --use-local pyinstrument
+    conda install --use-local click
 
-Now verify that Pyinstrument installed successfully:
+Now verify that click installed successfully:
 
 .. code-block:: bash
 
     conda list
 
-At this point you now have a conda package for pyinstrument that
+At this point you now have a conda package for click that
 can be installed in any conda environment of the same Python
 version as your root environment. The remaining optional sections
 show you how to make packages for other Python versions, other
@@ -152,11 +151,11 @@ By default, conda build creates packages for the version of
 Python installed in the root environment. To build packages for
 other versions of Python, you use the ``--python`` flag, followed
 by a version. For example, to explicitly build a version of the
-Pyinstrument package for Python 3.3, use:
+click package for Python 3.3, use:
 
 .. code-block:: bash
 
-    conda-build --python 3.3 pyinstrument
+    conda-build --python 3.3 click
 
 Notice that the file printed at the end of the ``conda-build``
 output has changed to reflect the requested version of Python.
@@ -167,21 +166,21 @@ Windows example file path:
 
 .. code-block:: text
 
-    C:\Users\jsmith\Miniconda\conda-bld\win-64\pyinstrument-0.13.1-py33_0.tar.bz2
+    C:\Users\jsmith\Miniconda\conda-bld\win-64\click-6.7-py33_0.tar.bz2
 
 
 OS X example file path:
 
 .. code-block:: text
 
-    /Users/jsmith/miniconda/conda-bld/osx-64/pyinstrument-0.13.1-py33_0.tar.bz2
+    /Users/jsmith/miniconda/conda-bld/osx-64/click-6.7-py33_0.tar.bz2
 
 
 Linux example file path:
 
 .. code-block:: text
 
-    /home/jsmith/miniconda/conda-bld/linux-64/pyinstrument-0.13.1-py33_0.tar.bz2
+    /home/jsmith/miniconda/conda-bld/linux-64/click-6.7-py33_0.tar.bz2
 
 
 NOTE: Your path and filename will vary depending on your
@@ -213,14 +212,14 @@ Windows:
 
 .. code-block:: text
 
-    conda convert -f --platform all C:\Users\jsmith\Miniconda\conda-bld\win-64\pyinstrument-0.13.1-py27_0.tar.bz2
+    conda convert -f --platform all C:\Users\jsmith\Miniconda\conda-bld\win-64\click-6.7-py27_0.tar.bz2
     -o outputdir\
 
 macOS and Linux:
 
 .. code-block:: text
 
-    conda convert --platform all /home/jsmith/miniconda/conda-bld/linux-64/pyinstrument-0.13.1-py27_0.tar.bz2
+    conda convert --platform all /home/jsmith/miniconda/conda-bld/linux-64/click-6.7-py27_0.tar.bz2
     -o outputdir/
 
 
@@ -265,14 +264,14 @@ Windows:
 
 .. code-block:: text
 
-    anaconda upload C:\Users\jsmith\Miniconda\conda-bld\win-64\pyinstrument-0.13.1-py27_0.tar.bz2
+    anaconda upload C:\Users\jsmith\Miniconda\conda-bld\win-64\click-6.7-py27_0.tar.bz2
 
 
 macOS and Linux:
 
 .. code-block:: text
 
-    anaconda upload /home/jsmith/miniconda/conda-bld/linux-64/pyinstrument-0.13.1-py27_0.tar.bz2
+    anaconda upload /home/jsmith/miniconda/conda-bld/linux-64/click-6.7-py27_0.tar.bz2
 
 
 NOTE: Change your path and filename to the exact path and

--- a/docs/source/user-guide/tutorials/build-pkgs.rst
+++ b/docs/source/user-guide/tutorials/build-pkgs.rst
@@ -8,8 +8,7 @@ Building conda packages from scratch
    :depth: 1
 
 This tutorial describes how to build a conda package for
-Pyinstrument by writing the required
-files in the conda build recipe.
+click by writing the required files in the conda build recipe.
 
 Who is this for?
 ================
@@ -34,13 +33,13 @@ Before you start
 Editing the meta.yaml file
 ===========================
 
-#. Make a new directory for this tutorial named ``pyinstrument``,
+#. Make a new directory for this tutorial named ``click``,
    and then change to the new directory:
 
    .. code-block:: bash
 
-     mkdir pyinstrument
-     cd pyinstrument
+     mkdir click
+     cd click
 
 #. To create a new ``meta.yaml`` file, open your favorite editor.
    Create a new text file and insert the information shown below.
@@ -54,19 +53,19 @@ Editing the meta.yaml file
       :widths: 10 90
 
       * - name
-        - pyinstrument
+        - click
       * - version
-        - "0.13.1" (or latest from
-          https://github.com/joerick/pyinstrument/releases)
+        - "6.7" (or latest from
+          https://github.com/pallets/click/releases)
       * - git_rev
-        - v0.13.1 (or latest from
-          https://github.com/joerick/pyinstrument/releases)
+        - 6.7 (or latest from
+          https://github.com/pallets/click/releases)
       * - git_url
-        - https://github.com/joerick/pyinstrument.git
+        - https://github.com/pallets/click.git
       * - imports
-        - pyinstrument
+        - click
       * - home
-        - https://github.com/joerick/pyinstrument
+        - https://github.com/pallets/click
       * - license
         - BSD
       * - license_file
@@ -99,7 +98,7 @@ Editing the meta.yaml file
        license:
        license_file:
 
-#. Save the file in the same ``pyinstrument``
+#. Save the file in the same ``click``
    directory as ``meta.yaml``. It should match :download:`this
    meta.yaml file <meta.yaml>`.
 
@@ -170,7 +169,7 @@ on your local computer.
 
    .. code-block:: bash
 
-      conda-build pyinstrument
+      conda-build click
 
    When conda build is finished, it displays the package filename
    and location.
@@ -179,7 +178,7 @@ on your local computer.
 
    .. code-block:: bash
 
-      ~/anaconda/conda-bld/linux-64/pyinstrument-0.13.1-py27_0.tar.bz2
+      ~/anaconda/conda-bld/linux-64/click-6.7-py27_0.tar.bz2
 
 
    NOTE: Save this path and file information for the next task.
@@ -222,7 +221,7 @@ EXAMPLE: Using the platform specifier ``all``:
 
 .. code-block:: bash
 
-     conda convert --platform all ~/anaconda/conda-bld/linux-64/pyinstrument-0.13.1-py27_0.tar.bz2 -o outputdir/
+     conda convert --platform all ~/anaconda/conda-bld/linux-64/click-6.7-py27_0.tar.bz2 -o outputdir/
 
 
 NOTE: Change your path and filename to the path and
@@ -244,20 +243,19 @@ Replace this ``source`` section:
 
 .. code-block:: bash
 
-   git_rev: v0.13.1
-   git_url: https://github.com/joerick/pyinstrument.git
+   git_rev: v0.6.7
+   git_url: https://github.com/pallets/click.git
 
 With the following:
 
 .. code-block:: bash
 
-    fn: pyinstrument-0.13.1.tar.gz
-    md5: e347036acc50720c0903dc2221b2605d
-    url: https://pypi.python.org/packages/source/p/pyinstrument/pyinstrument-0.13.1.tar.gz
+    url: https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz
+    sha256: f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b
 
 
-NOTE: The ``md5`` is found on the `PyPI Pyinstrument page
-<https://pypi.python.org/pypi/pyinstrument>`_.
+NOTE: The ``url`` and ``sha256`` is found on the `PyPI click page
+<https://pypi.org/project/click/#files>`_.
 
 
 .. _anaconda-org:


### PR DESCRIPTION
The pyinstrument package has a new release, 2.0.0b1, which adds a new dependency on pyinstrument_cext, also on pypi.  I recommend changing the docs to demonstrate a simpler, single-component package, such as click.  This PR does most of the work, but I have run out of time on it.

@cio-docs please replace remaining instances of pyinstrument with appropriate click references, and verify that the examples still run.