### PR TITLE
Fix the explanation of defaults_channels

### DIFF
--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -150,18 +150,17 @@ file. See :ref:`channel-alias`.
 Default channels (default_channels)
 -----------------------------------
 
-Normally the default repository is `repo.continuum.io
-<http:repo.continuum.io>`_, but if default_channels is defined,
-it sets the new list of default channels. This is especially
-useful for air gap and enterprise installations:
+Normally the defaults channel points to several channels at the
+`repo.continuum.io <http:repo.continuum.io>`_ repository, but if
+default_channels is defined, it sets the new list of default channels.
+This is especially useful for air gap and enterprise installations:
 
 .. code-block:: yaml
 
-  channels:
+  default_channels:
     - <anaconda_dot_org_username>
     - http://some.custom/channel
     - file:///some/local/directory
-    - defaults
 
 Update conda automatically (auto_update_conda)
 ----------------------------------------------


### PR DESCRIPTION
The defaults channel by default points to several channels.
The lis of channels can be overridden using the default_channels
configuration key.