### PR TITLE
Update enable-tab-completion.rst

### DIFF
--- a/docs/source/user-guide/configuration/enable-tab-completion.rst
+++ b/docs/source/user-guide/configuration/enable-tab-completion.rst
@@ -2,8 +2,8 @@
 Enabling tab completion
 ========================
 
-Conda supports tab completion in bash shells via the argcomplete
-package.
+Conda versions up to 4.3 supports tab completion in bash shells via the argcomplete
+package. Tab completion is deprecated starting with version 4.4. See `issue #415 <https://github.com/conda/conda-docs/issues/415>`_.
 
 To enable tab completion:
 


### PR DESCRIPTION
Tab completion is not supported in conda 4.4+. See #415.