### PR TITLE
Update copyright information on docs website to 2018

### DIFF
--- a/web/source/conf.py
+++ b/web/source/conf.py
@@ -45,7 +45,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Conda'
-copyright = '2017, Continuum Analytics'
+copyright = '2018, Continuum Analytics'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
https://conda.io is copyrighted to 2017, this patch updates to 2018. Perhaps a future update can automate this process.