### PR TITLE
add IP anonimization to google analytics for GDPR compliance

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -9,6 +9,7 @@
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-27761864-11', 'auto');
+  ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
See https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#anonymizeIp and http://www.blastam.com/blog/5-actionable-steps-gdpr-compliance-google-analytics