### PR TITLE
Document `git_depth`

### DIFF
--- a/docs/source/user-guide/tasks/build-packages/define-metadata.rst
+++ b/docs/source/user-guide/tasks/build-packages/define-metadata.rst
@@ -92,6 +92,7 @@ The git_url can also be a relative path to the recipe directory.
    source:
      git_url: https://github.com/ilanschnell/bsdiff4.git
      git_rev: 1.1.4
+     git_depth: 1  # (Defaults to -1/not shallow)
 
 
 Source from hg


### PR DESCRIPTION
Includes an example of using `git_depth` for a shallow clone with a comment about the default being a non-shallow clone.

xref: https://github.com/conda/conda-build/pull/604

cc @msarahan