### PR TITLE
Update define-metadata pep 386 to 440

### DIFF
--- a/docs/source/user-guide/tasks/build-packages/define-metadata.rst
+++ b/docs/source/user-guide/tasks/build-packages/define-metadata.rst
@@ -41,7 +41,7 @@ spaces.
 Package version
 ---------------
 
-The version number of the package. Use the PEP-386 verlib
+The version number of the package. Use the `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_ verlib
 conventions. Cannot contain "-". YAML interprets version numbers
 such as 1.0 as floats, meaning that 0.10 will be the same as 0.1.
 To avoid this, put the version number in quotes so that it is


### PR DESCRIPTION
Update based on 'Conda acknowledges PEP 440' under the version key in https://github.com/conda/conda-docs/blob/a2c634ae0d66abbf0e3cd35f7a52558edd0dec82/docs/source/user-guide/tasks/build-packages/package-spec.rst#package-metadata