### PR TITLE
Add comment for --env option

### DIFF
--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -111,7 +111,8 @@ EXAMPLE:
     - defaults
 
 To select channels for a single environment, put a ``.condarc``
-file in the root directory of that environment.
+file in the root directory of that environment (or use the
+``--env`` option when using ``conda config``).
 
 EXAMPLE: If you have installed Miniconda with Python 3 in your
 home directory and the environment is named "flowers", the


### PR DESCRIPTION
The paragraph on adding a .condarc per environment needed to mention the ``--env`` option of the `conda config` command.