### PR TITLE
py preprocessor is an int, not a string

### DIFF
--- a/docs/source/user-guide/tasks/build-packages/define-metadata.rst
+++ b/docs/source/user-guide/tasks/build-packages/define-metadata.rst
@@ -1536,7 +1536,7 @@ variables are booleans.
      - True if the platform is Windows and the Python
        architecture is 64-bit.
    * - py
-     - The Python version as a 2-digit string, such as ``'27'``.
+     - The Python version as an int, such as ``27`` or ``36``.
        See the CONDA_PY :ref:`environment variable <build-envs>`.
    * - py3k
      - True if the Python major version is 3.


### PR DESCRIPTION
ref: https://github.com/conda/conda-build/issues/2919

the `py` preprocessor is an int, but the docs incorrectly state that it is a string.