### PR TITLE
Fix search order for conda_build_config.yaml

### DIFF
--- a/docs/source/user-guide/tasks/build-packages/variants.rst
+++ b/docs/source/user-guide/tasks/build-packages/variants.rst
@@ -293,9 +293,9 @@ Creating conda-build variant config files
 
 Variant input files are yaml files.  Search order for these files is the following:
 
-1. a file named ``conda_build_config.yaml`` in the user's HOME folder
-2. an arbitrarily named file specified as the value for the
-   ``conda_build/config_file`` key in your .condarc file
+1. a file named ``conda_build_config.yaml`` in the user's HOME folder (or an arbitrarily named file specified as the value for the
+   ``conda_build/config_file`` key in your .condarc file)
+2. a file named ``conda_build_config.yaml`` in the current working directory
 3. a file named ``conda_build_config.yaml`` in the same folder as ``meta.yaml``
    with your recipe
 4. Any additional files specified on the command line with the


### PR DESCRIPTION
These corrections are based on my testing and reading of the 'find_config_files' function in 'variants.py' in the conda-build 3 source code ( https://github.com/conda/conda-build/blob/e2a4a8fd1d29347f6c12f8464d9537486b4be983/conda_build/variants.py#L140-L170 )

'cwd' was added to the search path for conda-build 3.0.0 in commit: https://github.com/conda/conda-build/commit/36c272542acb00aec0fd60ee44365af61a848c11

The behavior where the conda_build/config_file entry overrides the default location in home dir appears to be even older.