### PR TITLE
Make use of the CONDA_PREFIX environment variable

### DIFF
--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -382,12 +382,12 @@ Windows
 -------
 
 #. Locate the directory for the conda environment in your
-   Anaconda Prompt, such as ``C:\Users\jsmith\Anaconda3\envs\analytics``.
+   Anaconda Prompt by running in the command shell `%CONDA_PREFIX%`.
 
 #. Enter that directory and create these subdirectories and
    files::
 
-    cd C:\Users\jsmith\Anaconda3\envs\analytics
+    cd %CONDA_PREFIX%
     mkdir .\etc\conda\activate.d
     mkdir .\etc\conda\deactivate.d
     type NUL > .\etc\conda\activate.d\env_vars.bat

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -382,7 +382,7 @@ Windows
 -------
 
 #. Locate the directory for the conda environment in your
-   Anaconda Prompt by running in the command shell `%CONDA_PREFIX%`.
+   Anaconda Prompt by running in the command shell ``%CONDA_PREFIX%``.
 
 #. Enter that directory and create these subdirectories and
    files::
@@ -412,7 +412,7 @@ When you run ``deactivate``, those variables are erased.
 macOS and Linux
 ---------------
 
-#. Locate the directory for the conda environment in your Terminal window by running in the terminal `echo $CONDA_PREFIX`.
+#. Locate the directory for the conda environment in your Terminal window by running in the terminal ``echo $CONDA_PREFIX``.
 
 #. Enter that directory and create these subdirectories and
    files::

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -412,13 +412,12 @@ When you run ``deactivate``, those variables are erased.
 macOS and Linux
 ---------------
 
-#. Locate the directory for the conda environment in your Terminal window, such as
-   ``/home/jsmith/anaconda3/envs/analytics``.
+#. Locate the directory for the conda environment in your Terminal window by running in the terminal `echo $CONDA_PREFIX`.
 
 #. Enter that directory and create these subdirectories and
    files::
 
-     cd /home/jsmith/anaconda3/envs/analytics
+     cd $CONDA_PREFIX
      mkdir -p ./etc/conda/activate.d
      mkdir -p ./etc/conda/deactivate.d
      touch ./etc/conda/activate.d/env_vars.sh


### PR DESCRIPTION
Note: some change would have to be made also for the Windows instructions. I don't know what that change would be, having never used the shell on Windows.

Using the CONDA_PREFIX environment would make it easier to create build scripts which require editing of environment variables.

 This seems to be alluded to elsewhere in the conda documentation:

https://conda.io/docs/user-guide/tasks/build-packages/environment-variables.html

Here is a real-world use case where I could imagine this would be helpful for creating an easy-to-use conda package:

https://github.com/n-riesco/ijavascript/blob/master/doc/install.md#conda

In particular, editing environment variables seems to be necessary whenever one wants to install both a conda package with NPM package dependencies (and have the NPM package be specific to the conda environment). This is a big deal e.g. for JupyterLab extensions. For example: https://github.com/jupyterlab/jupyterlab-latex#installation

In general, this slight change to the docs might make it easier for conda package creators to use NPM package dependencies, possibly better integrating NPM and conda and thereby increasing adoption of conda.