### PR TITLE
(fix) Update rst syntax

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -11,8 +11,8 @@ If your issue is a bug report or feature request for:
 * **a specific conda package**: please file it at https://github.com/ContinuumIO/anaconda-issues/issues
 * **anaconda.org**: please file it at https://github.com/Anaconda-Platform/support/issues
 * **repo.anaconda.com**: please file it at https://github.com/ContinuumIO/anaconda-issues/issues
-* **commands under `conda build`**: please file it at https://github.com/conda/conda-build/issues
-* **commands under `conda env`**: please file it at https://github.com/conda/conda/issues
+* **commands under** ``conda build``: please file it at https://github.com/conda/conda-build/issues
+* **commands under** ``conda env``: please file it at https://github.com/conda/conda/issues
 * **all other conda commands**: please file it at https://github.com/conda/conda/issues
 
 


### PR DESCRIPTION
Fixed syntax for `conda build` and `conda env` commands on Contributing section.