### PR TITLE
changed description of deactivate command

### DIFF
--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -247,7 +247,7 @@ To deactivate an environment:
 
 * On macOS and Linux, in your Terminal Window, run ``source deactivate``
 
-Conda removes the path name ``myenv`` from your system command.
+The environment ``myenv`` is deactivated, and ``base`` environment is set as active.
 
 TIP: In Windows, it is good practice to deactivate one
 environment before activating another.

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -247,7 +247,7 @@ To deactivate an environment:
 
 * On macOS and Linux, in your Terminal Window, run ``source deactivate``
 
-The environment ``myenv`` is deactivated, and ``base`` environment is set as active.
+Conda removes the path name ``myenv`` from your system command. Unless you're using stacked environments, this simply means that the environment ``myenv`` is deactivated, and ``base`` environment is set as active.
 
 TIP: In Windows, it is good practice to deactivate one
 environment before activating another.


### PR DESCRIPTION
The current description of `deactivate` command was confusing to me - I assumed it was going to completely 'remove' the environment. I think the word 'remove' should be avoided in this context not to confuse people.