### PR TITLE
Update documentation how to get a list of environments

### DIFF
--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -127,11 +127,11 @@ name. For details see :ref:`Creating an environment file manually
 
    NOTE: Replace ``myenv`` with the name of the environment.
 
-#. Verify that the new environment was installed correctly:
+#. Verify that the new environment was installed correctly, active environment is shown with '*':
 
    .. code::
 
-      conda list
+      conda env list
 
 
 Cloning an environment


### PR DESCRIPTION
Update doc guidelines how to list all environments -  `conda env list` instead of `conda list` seems to be more appropriate in this fragment of documentation.

*Before*
`conda list` which lists all packages and versions installed in an active environment 

*Now*
`conda env list` which returns a list of all environments and shows which of them are active