### PR TITLE
update versions of python Anaconda supports

### DIFF
--- a/docs/source/user-guide/tasks/manage-python.rst
+++ b/docs/source/user-guide/tasks/manage-python.rst
@@ -10,14 +10,14 @@ Managing Python
 Conda treats Python the same as any other package, so it is easy
 to manage and update multiple installations.
 
-Anaconda supports Python 2.7, 3.4, 3.5 and 3.6. The default is Python
-2.7 or 3.6, depending on which installer you used:
+Anaconda supports Python 2.7, 3.6 and 3.7. The default is Python
+2.7 or 3.7, depending on which installer you used:
 
 * For the installers "Anaconda" and "Miniconda," the default is
   2.7.
 
 * For the installers "Anaconda3" or "Miniconda3," the default is
-  3.6.
+  3.7.
 
 
 Viewing a list of available Python versions


### PR DESCRIPTION
As of Anaconda v5.3, python 2.7, 3.6. & 3.7 are the supported versions of Python.