### PR TITLE
meta.yml docs: add "py37" selector to table of available selectors

### DIFF
--- a/docs/source/user-guide/tasks/build-packages/define-metadata.rst
+++ b/docs/source/user-guide/tasks/build-packages/define-metadata.rst
@@ -1550,6 +1550,8 @@ variables are booleans.
      - True if the Python version is 3.5.
    * - py36
      - True if the Python version is 3.6.
+   * - py37
+     - True if the Python version is 3.7.
    * - np
      - The NumPy version as an integer such as ``111``. See the
        CONDA_NPY :ref:`environment variable <build-envs>`.

--- a/docs/source/user-guide/tasks/build-packages/environment-variables.rst
+++ b/docs/source/user-guide/tasks/build-packages/environment-variables.rst
@@ -298,7 +298,7 @@ Environment variables that affect the build process
 
    * - CONDA_PY
      - The Python version used to build the package. Should
-       be ``27``, ``34``, ``35`` or ``36``.
+       be ``27``, ``35``, ``36`` or ``37``.
    * - CONDA_NPY
      - The NumPy version used to build the package, such as
        ``19``, ``110`` or ``111``.


### PR DESCRIPTION
Assuming that it works the same for the new Python 3.7 build environments?

---

On a side note, while searching for how to use the selectors, I stumbled across [these lines in smithy code](https://github.com/conda-forge/conda-smithy/blob/50626edaedd65d32cd4dc3b58c22de5b3c14dc8e/conda_smithy/update_cb3.py#L300-L316). It looks like some version comparisons are available for the selectors? I could not find it in these doc pages, so it feels like it is missing in the docs and should be added. Since I'm totally unsure about it though, I leave this to the maintainers.