### PR TITLE
Correct two commands in getting-started.rst

### DIFF
--- a/docs/source/user-guide/getting-started.rst
+++ b/docs/source/user-guide/getting-started.rst
@@ -140,7 +140,7 @@ Create separate environments to keep your programs isolated from each other.
 #. To use, or "activate" the new environment, type the following:
 
      * Windows:  ``activate snowflakes``
-     * Linux and macOS: ``source activate snowflakes``
+     * Linux and macOS: ``conda activate snowflakes``
 
    Now that you are in your ``snowflakes`` environment, any conda
    commands you type will go to that environment until
@@ -166,7 +166,7 @@ Create separate environments to keep your programs isolated from each other.
 #. Change your current environment back to the default (base):
 
      * Windows:  ``deactivate``
-     * Linux, macOS: ``source deactivate``
+     * Linux, macOS: ``conda deactivate``
 
    TIP: When the environment is deactivated, its name is no
    longer shown in your prompt, and the asterisk (*) returns to base.


### PR DESCRIPTION
I'm submitting a change for two commands which I believe are not correct. 

I'm brand new to conda/Anaconda. I followed the instructions in the Managing Environments section and `source activate snowflakes` and `source deactivate`did not work for me. However, `conda activate snowflakes` and `conda deactivate` did work for me.

I'm certainly open to hearing that I did something wrong and my proposed change is not correct.

Apologies in advance if my PR shouldn't be against `master`. This is my first PR for open source software, so I'm bound to get something wrong with it!