### PR TITLE
Remove spurious link to Anaconda Repository

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,7 +39,7 @@ of your code.
 
 The conda package and environment manager is included in all versions of
 Anaconda and Miniconda.
-`Anaconda Repository <https://docs.continuum.io/anaconda-repository/>`_.
+
 Conda is also included in `Anaconda Enterprise
 <https://www.anaconda.com/enterprise/>`_, which provides on-site enterprise
 package and environment management for Python, R, Node.js, Java and other


### PR DESCRIPTION
It links, out of the blue, to Anaconda Enterprise 4 Repository. Even though there is Anaconda Enterprise 5.