### PR TITLE
Fix emphasis role appearing in homepage content

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ Conda
 
 :emphasis:`Package, dependency and environment management for any
 language---Python, R, Ruby, Lua, Scala, Java, JavaScript, C/ C++,
-FORTRAN, and more.
+FORTRAN, and more.`
 
 Conda is an open source package management system and environment
 management system that runs on Windows, macOS and Linux. Conda


### PR DESCRIPTION
This adds a missing backtick to close out the `:emphasis:` section on the homepage for the docs, which previously appeared verbatim. 