### PR TITLE
Use a template to fill in Miniconda sizes and hashes

### DIFF
--- a/docs/source/create_miniconda_rst.py
+++ b/docs/source/create_miniconda_rst.py
@@ -1,0 +1,89 @@
+#! /usr/bin/env python
+""" create miniconda.rst file with size and sha256 for latest installers """
+
+import urllib.request
+import json
+
+from jinja2 import Template
+
+OUT_FILENAME = "miniconda.rst"
+TEMPLATE_FILENAME = "miniconda.rst.jinja2"
+FILES_URL = "https://repo.anaconda.com/miniconda/.files.json"
+
+
+def sizeof_fmt(num, suffix="B"):
+    for unit in ["", "Ki", "Mi", "Gi"]:
+        if abs(num) < 1024.0:
+            return "%3.1f %s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f %s%s" % (num, "Yi", suffix)
+
+
+def get_latest_miniconda_sizes_and_hashes():
+    with urllib.request.urlopen(urllib.request.Request(url=FILES_URL)) as f:
+        data = json.loads(f.read().decode("utf-8"))
+
+    win32_py2 = data['Miniconda2-latest-Windows-x86.exe']
+    win32_py3 = data['Miniconda3-latest-Windows-x86.exe']
+
+    win64_py2 = data['Miniconda2-latest-Windows-x86_64.exe']
+    win64_py3 = data['Miniconda3-latest-Windows-x86_64.exe']
+
+    osx64_sh_py2 = data['Miniconda2-latest-MacOSX-x86_64.sh']
+    osx64_sh_py3 = data['Miniconda3-latest-MacOSX-x86_64.sh']
+
+    osx64_pkg_py2 = data['Miniconda2-latest-MacOSX-x86_64.pkg']
+    osx64_pkg_py3 = data['Miniconda3-latest-MacOSX-x86_64.pkg']
+
+    linux32_py2 = data['Miniconda2-latest-Linux-x86.sh']
+    linux32_py3 = data['Miniconda3-latest-Linux-x86.sh']
+
+    linux64_py2 = data['Miniconda2-latest-Linux-x86_64.sh']
+    linux64_py3 = data['Miniconda3-latest-Linux-x86_64.sh']
+
+    info = {
+        'win32_py2_size': sizeof_fmt(win32_py2['size']),
+        'win32_py2_hash': win32_py2['sha256'],
+        'win32_py3_size': sizeof_fmt(win32_py3['size']),
+        'win32_py3_hash': win32_py3['sha256'],
+
+        'win64_py2_size': sizeof_fmt(win64_py2['size']),
+        'win64_py2_hash': win64_py2['sha256'],
+        'win64_py3_size': sizeof_fmt(win64_py3['size']),
+        'win64_py3_hash': win64_py3['sha256'],
+
+        'osx64_sh_py2_size': sizeof_fmt(osx64_sh_py2['size']),
+        'osx64_sh_py2_hash': osx64_sh_py2['sha256'],
+        'osx64_sh_py3_size': sizeof_fmt(osx64_sh_py3['size']),
+        'osx64_sh_py3_hash': osx64_sh_py3['sha256'],
+
+        'osx64_pkg_py2_size': sizeof_fmt(osx64_pkg_py2['size']),
+        'osx64_pkg_py2_hash': osx64_pkg_py2['sha256'],
+        'osx64_pkg_py3_size': sizeof_fmt(osx64_pkg_py3['size']),
+        'osx64_pkg_py3_hash': osx64_pkg_py3['sha256'],
+
+        'linux32_py2_size': sizeof_fmt(linux32_py2['size']),
+        'linux32_py2_hash': linux32_py2['sha256'],
+        'linux32_py3_size': sizeof_fmt(linux32_py3['size']),
+        'linux32_py3_hash': linux32_py3['sha256'],
+
+        'linux64_py2_size': sizeof_fmt(linux64_py2['size']),
+        'linux64_py2_hash': linux64_py2['sha256'],
+        'linux64_py3_size': sizeof_fmt(linux64_py3['size']),
+        'linux64_py3_hash': linux64_py3['sha256'],
+    }
+    return info
+
+
+def main():
+    rst_vars = get_latest_miniconda_sizes_and_hashes()
+    with open(TEMPLATE_FILENAME) as f:
+        template_text = f.read()
+    template = Template(template_text)
+    rst_text = template.render(**rst_vars)
+    with open(OUT_FILENAME, 'w') as f:
+        f.write(rst_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -1,3 +1,7 @@
+.. This page is generated from the create_miniconda_rst.py script.
+   To make changes edit the miniconda.rst.jinja2 file and execute the script
+   to re-generate miniconda.rst
+
 =========
 Miniconda
 =========
@@ -18,7 +22,7 @@ Windows installers
    :widths: 5, 10, 5, 80
 
    Python 3.7,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_,72.6 MiB,``a3a8921c2dec37f4ef37b9fa7b337dba237ccacec56bed3d8b8c300ed852c84f``
-   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe>`_,72.6 MiB,``789a0cafbc4c43fb53facced1a32203865bc1600e5baf70e97e0ce3d64aebd4b``
+   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe>`_,67.4 MiB,``789a0cafbc4c43fb53facced1a32203865bc1600e5baf70e97e0ce3d64aebd4b``
    Python 2.7,`Miniconda2 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Windows-x86_64.exe>`_,71.7 MiB,``9cf92cb336fd29c4fabbf22523d71a52623bf5ed7895d6cd079d569af5e4b7cd``
    ,`Miniconda2 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Windows-x86.exe>`_,66.3 MiB,``a90d5b689f8a57c0da85ad77d3efa683a23da9ddb19429587635d222d5d1005c``
 

--- a/docs/source/miniconda.rst.jinja2
+++ b/docs/source/miniconda.rst.jinja2
@@ -1,0 +1,137 @@
+.. This page is generated from the create_miniconda_rst.py script.
+   To make changes edit the miniconda.rst.jinja2 file and execute the script
+   to re-generate miniconda.rst
+
+=========
+Miniconda
+=========
+
+Miniconda is a free minimal installer for conda. It is a small, bootstrap
+version of Anaconda that includes only conda, Python, the packages they depend
+on, and a small number of other useful packages, including pip, zlib and a
+few others. Use the ``conda install command`` to install 720+ additional conda
+packages from the Anaconda repository.
+
+`See if Miniconda is right for you <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html#anaconda-or-miniconda>`_.
+
+Windows installers
+==================
+
+.. csv-table:: Windows
+   :header: Python version,Name,Size,SHA256 hash
+   :widths: 5, 10, 5, 80
+
+   Python 3.7,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_,{{ win64_py3_size }},``{{ win64_py3_hash }}``
+   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe>`_,{{ win32_py3_size }},``{{ win32_py3_hash}}``
+   Python 2.7,`Miniconda2 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Windows-x86_64.exe>`_,{{ win64_py2_size }},``{{ win64_py2_hash }}``
+   ,`Miniconda2 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Windows-x86.exe>`_,{{ win32_py2_size }},``{{ win32_py2_hash }}``
+
+
+MacOSX installers
+=================
+
+.. csv-table:: MacOSX
+   :header: Python version,Name,Size,SHA256 hash
+   :widths: 5, 10, 5, 80
+
+   Python 3.7,`Miniconda3 MacOSX 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh>`_,{{ osx64_sh_py3_size }},``{{ osx64_sh_py3_hash }}``
+   ,`Miniconda3 MacOSX 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py3_size }},``{{ osx64_pkg_py3_hash }}``
+   Python 2.7,`Miniconda2 MacOSX 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda2-latest-MacOSX-x86_64.sh>`_,{{ osx64_sh_py2_size }},``{{ osx64_sh_py2_hash }}``
+   ,`Miniconda2 MacOSX 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda2-latest-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py2_size }},``{{ osx64_pkg_py2_hash }}``
+
+Linux installers
+================
+
+.. csv-table:: Linux
+   :header: Python version,Name,Size,SHA256 hash
+   :widths: 5, 10, 5, 80
+
+   Python 3.7,`Miniconda Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,{{ linux64_py3_size}},``{{ linux64_py3_hash }}``
+   ,`Miniconda3 Linux 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86.sh>`_,{{ linux32_py3_size }},``{{ linux32_py3_hash }}``
+   Python 2.7,`Miniconda2 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86_64.sh>`_,{{ linux64_py2_size }},``{{ linux64_py2_hash }}``
+   ,`Miniconda2 Linux 32-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86.sh>`_,{{ linux32_py2_size }},``{{ linux32_py2_hash }}``
+
+Installing
+==========
+- :doc:`See hashes for all Miniconda installers <../miniconda_hashes>`.
+- `Verify your installation <https://conda.io/projects/conda/en/latest/user-guide/install/download.html#cryptographic-hash-verification>`_.
+- `Installation
+  instructions <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`__.
+
+Other resources
+===============
+
+ -  `Miniconda with Python 3.7 for Power8 &
+    Power9 <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`__
+ -  `Miniconda with Python 2.7 for Power8 &
+    Power9 <https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-ppc64le.sh>`__
+ -  `Miniconda Docker
+    images <https://hub.docker.com/r/continuumio/>`__
+ -  `Miniconda AWS
+    images <https://aws.amazon.com/marketplace/seller-profile?id=29f81979-a535-4f44-9e9f-6800807ad996>`__
+ -  `Archive and MD5 sums for the
+    installers <https://repo.anaconda.com/miniconda/>`__
+ -  `conda change
+    log <https://conda.io/projects/continuumio-conda/en/latest/release-notes.html>`__
+
+ These Miniconda installers contain the conda
+ package manager and Python. Once Miniconda is
+ installed, you can use the conda command to install
+ any other packages and create environments, etc.
+ For example:
+
+ .. container:: highlight-bash notranslate
+
+    .. container:: highlight
+
+       ::
+
+          $ conda install numpy
+          ...
+          $ conda create -n py3k anaconda python=3
+          ...
+
+ There are two variants of the installer: Miniconda
+ is Python 2 based and Miniconda3 is Python 3 based.
+ Note that the choice of which Miniconda is
+ installed only affects the root environment.
+ Regardless of which version of Miniconda you
+ install, you can still install both Python 2.x and
+ Python 3.x environments.
+
+ The other difference is that the Python 3 version
+ of Miniconda will default to Python 3 when creating
+ new environments and building packages. So for
+ instance, the behavior of:
+
+ .. container:: highlight-bash notranslate
+
+    .. container:: highlight
+
+       ::
+
+          $ conda create -n myenv python
+
+ will be to install Python 2.7 with the Python 2
+ Miniconda and to install Python 3.7 with the Python
+ 3 Miniconda. You can override the default by
+ explicitly setting ``python=2`` or ``python=3``. It
+ also determines the default value of ``CONDA_PY``
+ when using ``conda build``.
+
+ .. note::
+    If you already have Miniconda or Anaconda
+    installed, and you just want to upgrade, you should
+    not use the installer. Just use ``conda update``.
+ 
+ For instance:
+
+ .. container:: highlight-bash notranslate
+
+    .. container:: highlight
+
+       ::
+
+          $ conda update conda
+
+ will update conda.


### PR DESCRIPTION
Create the miniconda.rst file from a script which fills in the sizes and hashes for the latest Miniconda installers.