### PR TITLE
miniconda3 install

### DIFF
--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -436,11 +436,15 @@ packages to the latest version.
 
 In this case, if you would prefer that conda update all dependencies
 to the latest version that is compatible with the environment,
-set update_dependencies to ``True``:
+set update_dependencies to ``True``.
+
+The default is ``False``.
+
+EXAMPLE:
 
 .. code-block:: yaml
 
-   update_dependencies: False
+   update_dependencies: True
 
 NOTE: Conda still ensures that dependency specifications are
 satisfied. Thus, some dependencies may still be updated or,


### PR DESCRIPTION
Hi, Dear conda team,

When I am trying install miniconda3 on centos7, I faced this error
Executing transaction: / WARNING conda.core.envs_manager:register_env(46): Unable to register environment. Path not writable or missing.
Could you please give me some advises? 
Thank you very much.