### PR TITLE
Docs name 'change'

### DIFF
--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -46,7 +46,7 @@ Linux installers
    :header: Python version,Name,Size,SHA256 hash
    :widths: 5, 10, 5, 80
 
-   Python 3.7,`Miniconda Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,71.8 MiB,``8a324adcc9eaf1c09e22a992bb6234d91a94146840ee6b11c114ecadafc68121``
+   Python 3.7,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,71.8 MiB,``8a324adcc9eaf1c09e22a992bb6234d91a94146840ee6b11c114ecadafc68121``
    ,`Miniconda3 Linux 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86.sh>`_,62.7 MiB,``f387eded3fa4ddc3104b7775e62d59065b30205c2758a8b86b4c27144adafcc4``
    Python 2.7,`Miniconda2 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86_64.sh>`_,49.7 MiB,``9b1c7899f3bfcd520203eb7d51bfe456e25e5700dfa877c09bd2dbb028c305d8``
    ,`Miniconda2 Linux 32-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86.sh>`_,39.0 MiB,``2e20ac4379ca5262e7612f84ad26b1a2f2782d0994facdecb28e0baf51749979``


### PR DESCRIPTION
The installer file is still called Miniconda3, but it can be unclear if you get told in some guide or something, "Install Miniconda3 from here:" which one to grab.

Can easily lead to pulling the 32 bit one.