### PR TITLE
fix Fortran name

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ Conda
 
 *Package, dependency and environment management for any
 language---Python, R, Ruby, Lua, Scala, Java, JavaScript, C/ C++,
-FORTRAN, and more.*
+Fortran, and more.*
 
 Conda is an open source package management system and environment
 management system that runs on Windows, macOS and Linux. Conda


### PR DESCRIPTION
Fortran is spelled as "FORTRAN" on the main page. The correct name is "Fortran".