### PR TITLE
Missing 3

### DIFF
--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -46,7 +46,7 @@ Linux installers
    :header: Python version,Name,Size,SHA256 hash
    :widths: 5, 10, 5, 80
 
-   Python 3.7,`Miniconda Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,81.1 MiB,``957d2f0f0701c3d1335e3b39f235d197837ad69a944fa6f5d8ad2c686b69df3b``
+   Python 3.7,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,81.1 MiB,``957d2f0f0701c3d1335e3b39f235d197837ad69a944fa6f5d8ad2c686b69df3b``
    ,`Miniconda3 Linux 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86.sh>`_,62.7 MiB,``f387eded3fa4ddc3104b7775e62d59065b30205c2758a8b86b4c27144adafcc4``
    Python 2.7,`Miniconda2 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86_64.sh>`_,46.0 MiB,``383fe7b6c2574e425eee3c65533a5101e68a2d525e66356844a80aa02a556695``
    ,`Miniconda2 Linux 32-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86.sh>`_,39.0 MiB,``2e20ac4379ca5262e7612f84ad26b1a2f2782d0994facdecb28e0baf51749979``


### PR DESCRIPTION
I was confused that under Python 3.7 it's `Miniconda` (which was said to be Python 2 based)

> There are two variants of the installer: Miniconda is Python 2 based and Miniconda3 is Python 3 based.