### PR TITLE
Added Perl to list of supported languages

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ Conda
 |
 
 *Package, dependency and environment management for any
-language---Python, R, Ruby, Lua, Scala, Java, JavaScript, C/ C++,
+language---Python, R, Ruby, Perl, Lua, Scala, Java, JavaScript, C/ C++,
 FORTRAN, and more.*
 
 Conda is an open source package management system and environment


### PR DESCRIPTION
Certainly correct me if I’m wrong, but I believe that conda supports Perl, and if it does, it’s probably worth mentioning this in the list of other common languages (and if it doesn’t then maybe that should be mentioned instead, because Perl is so common)