### PR TITLE
miniconda.rst: Remove new section, remove mention of anaconda2/miniconda2

### DIFF
--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -115,34 +115,6 @@ Other resources
           $ conda create -n py3k anaconda python=3
           ...
 
- There are two variants of the installer: Miniconda
- is Python 2 based and Miniconda3 is Python 3 based.
- Note that the choice of which Miniconda is
- installed only affects the root environment.
- Regardless of which version of Miniconda you
- install, you can still install both Python 2.x and
- Python 3.x environments.
-
- The other difference is that the Python 3 version
- of Miniconda will default to Python 3 when creating
- new environments and building packages. So for
- instance, the behavior of:
-
- .. container:: highlight-bash notranslate
-
-    .. container:: highlight
-
-       ::
-
-          $ conda create -n myenv python
-
- will be to install Python 2.7 with the Python 2
- Miniconda and to install Python 3.8 with the Python
- 3 Miniconda. You can override the default by
- explicitly setting ``python=2`` or ``python=3``. It
- also determines the default value of ``CONDA_PY``
- when using ``conda build``.
-
  .. note::
     If you already have Miniconda or Anaconda
     installed, and you just want to upgrade, you should

--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -28,22 +28,6 @@ which does not require administrator permissions and is the most robust type of
 installation. However, if you need to, you can install Miniconda system wide,
 which does require administrator permissions.
 
-Latest Miniconda Installer Links
-================================
-
-.. csv-table:: Latest - Conda 4.10.3 Python 3.9.5 released July 21, 2021
-   :header: Platform,Name,SHA256 hash
-   :widths: 5, 10, 80
-
-   Windows,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_,``b33797064593ab2229a0135dc69001bea05cb56a20c2f243b1231213642e260a``
-   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe>`_,``24f438e57ff2ef1ce1e93050d4e9d13f5050955f759f448d84a4018d3cd12d6b``
-   MacOSX,`Miniconda3 MaxOSX 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh>`_,``786de9721f43e2c7d2803144c635f5f6e4823483536dc141ccd82dbb927cd508``
-   ,`Miniconda3 MaxOSX 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_,``8fa371ae97218c3c005cd5f04b1f40156d1506a9bd1d5c078f89d563fd416816``
-   Linux,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,``1ea2f885b4dbc3098662845560bc64271eb17085387a70c2ba3f29fff6f8d52f``
-   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh>`_,``4879820a10718743f945d88ef142c3a4b30dfc8e448d1ca08e019586374b773f``
-   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`_,``fa92ee4773611f58ed9333f977d32bbb64769292f605d518732183be1f3321fa``
-   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-s390x.sh>`_,``1faed9abecf4a4ddd4e0d8891fc2cdaa3394c51e877af14ad6b9d4aadb4e90d8``
-
 Windows installers
 ==================
 


### PR DESCRIPTION
A commit a month ago added a "Latest Miniconda Installer Links" section that's not built from the automation scripts around hashes. It also had a typo ("MaxOSX" rather than "MacOSX"). Earlier I did a pull request that just fixed the name, but looking at the automation around this, it's better to just remove the new section and leave users to go to their OS section like they used to.