### PR TITLE
fixed typo for code block

### DIFF
--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -9,7 +9,7 @@ Miniconda
 Miniconda is a free minimal installer for conda. It is a small, bootstrap
 version of Anaconda that includes only conda, Python, the packages they depend
 on, and a small number of other useful packages, including pip, zlib and a
-few others. Use the ``conda install command`` to install 720+ additional conda
+few others. Use the ``conda install`` command to install 720+ additional conda
 packages from the Anaconda repository.
 
 `See if Miniconda is right for you <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html#anaconda-or-miniconda>`_.


### PR DESCRIPTION
Changed code block styling to make it less confusing. From "``conda install command``" to "``conda install`` command"