### PR TITLE
Adding glibc-related Details to Miniconda Installation Requirements

### DIFF
--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -21,6 +21,7 @@ System requirements
 * Operating system: Windows 8 or newer, 64-bit macOS 10.13+, or Linux, including Ubuntu, RedHat, CentOS 7+, and others.
 * If your operating system is older than what is currently supported, you can find older versions of the Miniconda installers in our `archive <https://repo.anaconda.com/miniconda/>`_ that might work for you. 
 * System architecture: Windows- 64-bit x86, 32-bit x86; macOS- 64-bit x86 & Apple M1 (ARM64); Linux- 64-bit x86, 64-bit aarch64 (AWS Graviton2 / ARM64), 64-bit IBM Power8/Power9, s390x (Linux on IBM Z & LinuxONE).
+* The ``linux-aarch64`` Miniconda installer requires ``glibc >=2.26`` and thus will **not** work with CentOS 7, Ubuntu 16.04, or Debian 9 ("stretch").
 * Minimum 400 MB disk space to download and install.
 
 On Windows, macOS, and Linux, it is best to install Miniconda for the local user,


### PR DESCRIPTION
Connecting issues https://github.com/conda/conda-docs/issues/757 and https://github.com/conda/conda/issues/11107

It is currently unclear that `glibc >=2.26` is a requirement for the `linux-aarch64` Miniconda installer; adding this information to the docs.