### PR TITLE
Miniconda3 v4.11.0 release.

### DIFF
--- a/docs/source/create_miniconda_hash_rst.py
+++ b/docs/source/create_miniconda_hash_rst.py
@@ -4,10 +4,12 @@ import urllib.request
 import json
 import datetime
 import math
+import os
+import time
 from distutils.version import LooseVersion
 
 # Column lengths
-FILENAME_LEN = 40
+FILENAME_LEN = 42
 SIZE_LEN = 9
 TIMEMOD_LEN = 19
 HASH_LEN = 68
@@ -33,24 +35,24 @@ def main():
 
     # write file with hashes for all files
     f = open(OUT_FILENAME, "w")
-    f.write(":orphan:\n")
+    f.write(":orphan:\n\n")
     title = "Miniconda hash information"
     f.write("=" * len(title) + "\n" + title + "\n" + "=" * len(title) + "\n\n")
     f.write(
         "=" * FILENAME_LEN
-        + "  "
+        + "   "
         + "=" * SIZE_LEN
-        + "  "
+        + "   "
         + "=" * TIMEMOD_LEN
-        + " "
+        + "  "
         + "=" * HASH_LEN
         + "\n"
     )
     f.write(
         "Name".ljust(FILENAME_LEN)
-        + "  "
+        + "   "
         + "Size".ljust(SIZE_LEN)
-        + "  "
+        + "   "
         + "Time modified".ljust(TIMEMOD_LEN)
         + "  "
         + "SHA256 hash".ljust(HASH_LEN)
@@ -58,11 +60,11 @@ def main():
     )
     f.write(
         "=" * FILENAME_LEN
-        + "  "
+        + "   "
         + "=" * SIZE_LEN
-        + "  "
+        + "   "
         + "=" * TIMEMOD_LEN
-        + " "
+        + "  "
         + "=" * HASH_LEN
         + "\n"
     )
@@ -73,6 +75,12 @@ def main():
         if "_" in version_str:
             version_str = version_str.split("_")[1]
         return LooseVersion(version_str)
+    # =================================================================
+    # the main hosting server is central time, so pretend we are too
+    # in order for anyone to be able to run this on Unix platforms.
+    os.environ['TZ'] = 'US/Central'
+    time.tzset()
+    # =================================================================
     for filename in sorted(data, reverse=True, key=sorting_key):
         last_modified = datetime.datetime.fromtimestamp(
             math.floor(data[filename]["mtime"])
@@ -85,9 +93,9 @@ def main():
             continue
         f.write(
             filename.ljust(FILENAME_LEN)
-            + "  "
-            + sizeof_fmt(data[filename]["size"]).ljust(SIZE_LEN)
-            + "  "
+            + "   "
+            + sizeof_fmt(data[filename]["size"]).rjust(SIZE_LEN)
+            + "   "
             + last_mod_str.ljust(TIMEMOD_LEN)
             + "  "
             + "``"
@@ -96,11 +104,11 @@ def main():
         )
     f.write(
         "=" * FILENAME_LEN
-        + "  "
+        + "   "
         + "=" * SIZE_LEN
-        + "  "
+        + "   "
         + "=" * TIMEMOD_LEN
-        + " "
+        + "  "
         + "=" * HASH_LEN
         + "\n"
     )

--- a/docs/source/create_miniconda_rst.py
+++ b/docs/source/create_miniconda_rst.py
@@ -10,6 +10,20 @@ OUT_FILENAME = "miniconda.rst"
 TEMPLATE_FILENAME = "miniconda.rst.jinja2"
 FILES_URL = "https://repo.anaconda.com/miniconda/.files.json"
 
+CONDA_VERSION = "4.10.3"
+PLATFORM_MAP = {
+    "win32": "Windows-x86.exe",
+    "win64": "Windows-x86_64.exe",
+    "osx64_sh": "MacOSX-x86_64.sh",
+    "osx64_pkg": "MacOSX-x86_64.pkg",
+    "osx_arm64_sh": "MacOSX-arm64.sh",
+    "linux32": "Linux-x86.sh",
+    "linux64": "Linux-x86_64.sh",
+    "linux_aarch64": "Linux-aarch64.sh",
+    "linux_ppc64le": "Linux-ppc64le.sh",
+    "linux_s390x": "Linux-s390x.sh",
+}
+
 
 def sizeof_fmt(num, suffix="B"):
     for unit in ["", "Ki", "Mi", "Gi"]:
@@ -23,55 +37,20 @@ def get_latest_miniconda_sizes_and_hashes():
     with urllib.request.urlopen(urllib.request.Request(url=FILES_URL)) as f:
         data = json.loads(f.read().decode("utf-8"))
 
-    win32_py2 = data['Miniconda2-latest-Windows-x86.exe']
-    win32_py3 = data['Miniconda3-latest-Windows-x86.exe']
-
-    win64_py2 = data['Miniconda2-latest-Windows-x86_64.exe']
-    win64_py3 = data['Miniconda3-latest-Windows-x86_64.exe']
-
-    osx64_sh_py2 = data['Miniconda2-latest-MacOSX-x86_64.sh']
-    osx64_sh_py3 = data['Miniconda3-latest-MacOSX-x86_64.sh']
-
-    osx64_pkg_py2 = data['Miniconda2-latest-MacOSX-x86_64.pkg']
-    osx64_pkg_py3 = data['Miniconda3-latest-MacOSX-x86_64.pkg']
-
-    linux32_py2 = data['Miniconda2-latest-Linux-x86.sh']
-    linux32_py3 = data['Miniconda3-latest-Linux-x86.sh']
-
-    linux64_py2 = data['Miniconda2-latest-Linux-x86_64.sh']
-    linux64_py3 = data['Miniconda3-latest-Linux-x86_64.sh']
-
     info = {
-        'win32_py2_size': sizeof_fmt(win32_py2['size']),
-        'win32_py2_hash': win32_py2['sha256'],
-        'win32_py3_size': sizeof_fmt(win32_py3['size']),
-        'win32_py3_hash': win32_py3['sha256'],
-
-        'win64_py2_size': sizeof_fmt(win64_py2['size']),
-        'win64_py2_hash': win64_py2['sha256'],
-        'win64_py3_size': sizeof_fmt(win64_py3['size']),
-        'win64_py3_hash': win64_py3['sha256'],
-
-        'osx64_sh_py2_size': sizeof_fmt(osx64_sh_py2['size']),
-        'osx64_sh_py2_hash': osx64_sh_py2['sha256'],
-        'osx64_sh_py3_size': sizeof_fmt(osx64_sh_py3['size']),
-        'osx64_sh_py3_hash': osx64_sh_py3['sha256'],
-
-        'osx64_pkg_py2_size': sizeof_fmt(osx64_pkg_py2['size']),
-        'osx64_pkg_py2_hash': osx64_pkg_py2['sha256'],
-        'osx64_pkg_py3_size': sizeof_fmt(osx64_pkg_py3['size']),
-        'osx64_pkg_py3_hash': osx64_pkg_py3['sha256'],
-
-        'linux32_py2_size': sizeof_fmt(linux32_py2['size']),
-        'linux32_py2_hash': linux32_py2['sha256'],
-        'linux32_py3_size': sizeof_fmt(linux32_py3['size']),
-        'linux32_py3_hash': linux32_py3['sha256'],
-
-        'linux64_py2_size': sizeof_fmt(linux64_py2['size']),
-        'linux64_py2_hash': linux64_py2['sha256'],
-        'linux64_py3_size': sizeof_fmt(linux64_py3['size']),
-        'linux64_py3_hash': linux64_py3['sha256'],
+        "conda_version": CONDA_VERSION
     }
+    for platform_id, installer_suffix in PLATFORM_MAP.items():
+        latest_installer = 'Miniconda3-latest-{}'.format(installer_suffix)
+        info["{}_py3_latest_size".format(platform_id)] = sizeof_fmt(data[latest_installer]['size'])
+        info["{}_py3_latest_hash".format(platform_id)] = data[latest_installer]['sha256']
+        for py_version in ("37", "38", "39"):
+            full_installer = 'Miniconda3-py{}_{}-{}'.format(py_version, CONDA_VERSION, installer_suffix)
+            if full_installer not in data:
+                continue
+            info["{}_py{}_size".format(platform_id, py_version)] = sizeof_fmt(data[full_installer]['size'])
+            info["{}_py{}_hash".format(platform_id, py_version)] = data[full_installer]['sha256']
+
     return info
 
 

--- a/docs/source/create_miniconda_rst.py
+++ b/docs/source/create_miniconda_rst.py
@@ -10,7 +10,7 @@ OUT_FILENAME = "miniconda.rst"
 TEMPLATE_FILENAME = "miniconda.rst.jinja2"
 FILES_URL = "https://repo.anaconda.com/miniconda/.files.json"
 
-CONDA_VERSION = "4.10.3"
+CONDA_VERSION = "4.11.0"
 PLATFORM_MAP = {
     "win32": "Windows-x86.exe",
     "win64": "Windows-x86_64.exe",

--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -17,9 +17,9 @@ packages from the Anaconda repository.
 System requirements
 ===================
 
-* License: Free use and redistribution under the terms of the `EULA for Miniconda <https://www.anaconda.com/end-user-license-agreement-miniconda>`_. 
+* License: Free use and redistribution under the terms of the `EULA for Miniconda <https://www.anaconda.com/end-user-license-agreement-miniconda>`_.
 * Operating system: Windows 8 or newer, 64-bit macOS 10.13+, or Linux, including Ubuntu, RedHat, CentOS 7+, and others.
-* If your operating system is older than what is currently supported, you can find older versions of the Miniconda installers in our `archive <https://repo.anaconda.com/miniconda/>`_ that might work for you. 
+* If your operating system is older than what is currently supported, you can find older versions of the Miniconda installers in our `archive <https://repo.anaconda.com/miniconda/>`_ that might work for you.
 * System architecture: Windows- 64-bit x86, 32-bit x86; macOS- 64-bit x86 & Apple M1 (ARM64); Linux- 64-bit x86, 64-bit aarch64 (AWS Graviton2 / ARM64), 64-bit IBM Power8/Power9, s390x (Linux on IBM Z & LinuxONE).
 * The ``linux-aarch64`` Miniconda installer requires ``glibc >=2.26`` and thus will **not** work with CentOS 7, Ubuntu 16.04, or Debian 9 ("stretch").
 * Minimum 400 MB disk space to download and install.
@@ -40,7 +40,7 @@ Latest Miniconda Installer Links
    ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe>`_,``24f438e57ff2ef1ce1e93050d4e9d13f5050955f759f448d84a4018d3cd12d6b``
    MacOSX,`Miniconda3 MacOSX 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh>`_,``786de9721f43e2c7d2803144c635f5f6e4823483536dc141ccd82dbb927cd508``
    ,`Miniconda3 MacOSX 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_,``8fa371ae97218c3c005cd5f04b1f40156d1506a9bd1d5c078f89d563fd416816``
-   ,`Miniconda3 macOS Apple M1 64-bit bash (Py38 conda 4.10.1 2021-11-08) <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh>`_,``4ce4047065f32e991edddbb63b3c7108e7f4534cfc1efafc332454a414deab58``   
+   ,`Miniconda3 macOS Apple M1 64-bit bash (Py38 conda 4.10.1 2021-11-08) <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh>`_,``4ce4047065f32e991edddbb63b3c7108e7f4534cfc1efafc332454a414deab58``
    Linux,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,``1ea2f885b4dbc3098662845560bc64271eb17085387a70c2ba3f29fff6f8d52f``
    ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh>`_,``4879820a10718743f945d88ef142c3a4b30dfc8e448d1ca08e019586374b773f``
    ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`_,``fa92ee4773611f58ed9333f977d32bbb64769292f605d518732183be1f3321fa``
@@ -58,7 +58,7 @@ Windows installers
    Python 3.7,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Windows-x86_64.exe>`_,55.8 MiB,``9c031506bfcb0428a0ac46c9152f9bdd48d5bdaa83046691bf8e0a4480663c05``
    Python 3.9,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Windows-x86.exe>`_,55.3 MiB,``24f438e57ff2ef1ce1e93050d4e9d13f5050955f759f448d84a4018d3cd12d6b``
    Python 3.8,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Windows-x86.exe>`_,54.5 MiB,``f81c165384c18d1986e2ba2f86cef384bc62266c46b34cd3d274e751ff5d91ed``
-   Python 3.7,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Windows-x86.exe>`_,55.3 MiB,``a1bb8338be12ee09dbd4cab9dcc2fbdc99f65d99281dd2c07d24ad0f23dd1f7c``
+   Python 3.7,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Windows-x86.exe>`_,52.9 MiB,``a1bb8338be12ee09dbd4cab9dcc2fbdc99f65d99281dd2c07d24ad0f23dd1f7c``
 
 
 macOS installers
@@ -72,7 +72,7 @@ macOS installers
    ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-MacOSX-x86_64.pkg>`_,49.9 MiB,``8fa371ae97218c3c005cd5f04b1f40156d1506a9bd1d5c078f89d563fd416816``
    Python 3.8,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-MacOSX-x86_64.sh>`_,53.3 MiB,``93e514e01142866629175f5a9e2e1d0bac8bc705f61d1ed1da3c010b7225683a``
    ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-MacOSX-x86_64.pkg>`_,60.8 MiB,``faab44cd21b4b09f5c032aa49a8a23d3c53ef629dc9322411348ce413e41df35``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.1-MacOSX-arm64.sh>`_,44.9 MiB,``4ce4047065f32e991edddbb63b3c7108e7f4534cfc1efafc332454a414deab58``   
+   ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.1-MacOSX-arm64.sh>`_,44.9 MiB,``4ce4047065f32e991edddbb63b3c7108e7f4534cfc1efafc332454a414deab58``
    Python 3.7,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-MacOSX-x86_64.sh>`_,50.6 MiB,``ca7492d456c319d15682b2d3845112a631365f293d38d1f62872c33a2e57e430``
    ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-MacOSX-x86_64.pkg>`_,58.1 MiB,``c3710f25748884741ef8d97777ebb3541c992d51130298830b5b9ad449dbbf1e``
 
@@ -166,7 +166,7 @@ Other resources
     If you already have Miniconda or Anaconda
     installed, and you just want to upgrade, you should
     not use the installer. Just use ``conda update``.
- 
+
  For instance:
 
  .. container:: highlight-bash notranslate

--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -106,8 +106,6 @@ Installing
 Other resources
 ===============
 
- -  `Miniconda with Python 3.9 for Power8 &
-    Power9 <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`__
  -  `Miniconda Docker
     images <https://hub.docker.com/r/continuumio/>`__
  -  `Miniconda AWS

--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -32,19 +32,19 @@ which does require administrator permissions.
 Latest Miniconda Installer Links
 ================================
 
-.. csv-table:: Latest - Conda 4.10.3 Python 3.9.5 released July 21, 2021
+.. csv-table:: Latest - Conda 4.11.0 Python 3.9.7 released February 15, 2022
    :header: Platform,Name,SHA256 hash
    :widths: 5, 10, 80
 
-   Windows,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_,``b33797064593ab2229a0135dc69001bea05cb56a20c2f243b1231213642e260a``
-   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe>`_,``24f438e57ff2ef1ce1e93050d4e9d13f5050955f759f448d84a4018d3cd12d6b``
-   MacOSX,`Miniconda3 MacOSX 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh>`_,``786de9721f43e2c7d2803144c635f5f6e4823483536dc141ccd82dbb927cd508``
-   ,`Miniconda3 MacOSX 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_,``8fa371ae97218c3c005cd5f04b1f40156d1506a9bd1d5c078f89d563fd416816``
+   Windows,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_,``6013152b169c2c2d4bcd75bb03a1b8bf208b8545d69116a59351af695d9a0081``
+   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe>`_,``12a3a7e8aab7a974705ea4ee5bfc44f7c733241dd1b022f8012cbd42309b8472``
+   MacOSX,`Miniconda3 MacOSX 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh>`_,``7717253055e7c09339cd3d0815a0b1986b9138dcfcb8ec33b9733df32dd40eaa``
+   ,`Miniconda3 MacOSX 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_,``d3e63d7e8aa3ffb7b095e0b984db47309bb1cb1ec2138f5e6a96a34173671451``
    ,`Miniconda3 macOS Apple M1 64-bit bash (Py38 conda 4.10.1 2021-11-08) <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh>`_,``4ce4047065f32e991edddbb63b3c7108e7f4534cfc1efafc332454a414deab58``
-   Linux,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,``1ea2f885b4dbc3098662845560bc64271eb17085387a70c2ba3f29fff6f8d52f``
-   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh>`_,``4879820a10718743f945d88ef142c3a4b30dfc8e448d1ca08e019586374b773f``
-   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`_,``fa92ee4773611f58ed9333f977d32bbb64769292f605d518732183be1f3321fa``
-   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-s390x.sh>`_,``1faed9abecf4a4ddd4e0d8891fc2cdaa3394c51e877af14ad6b9d4aadb4e90d8``
+   Linux,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,``4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4``
+   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh>`_,``00c7127a8a8d3f4b9c2ab3391c661239d5b9a88eafe895fd0f3f2a8d9c0f4556``
+   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`_,``8ee1f8d17ef7c8cb08a85f7d858b1cb55866c06fcf7545b98c3b82e4d0277e66``
+   ,`Miniconda3 Linux-s390x 64-bit (conda 4.10.3 2021-07-21) <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-s390x.sh>`_,``1faed9abecf4a4ddd4e0d8891fc2cdaa3394c51e877af14ad6b9d4aadb4e90d8``
 
 Windows installers
 ==================
@@ -53,12 +53,12 @@ Windows installers
    :header: Python version,Name,Size,SHA256 hash
    :widths: 5, 10, 5, 80
 
-   Python 3.9,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Windows-x86_64.exe>`_,58.1 MiB,``b33797064593ab2229a0135dc69001bea05cb56a20c2f243b1231213642e260a``
-   Python 3.8,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Windows-x86_64.exe>`_,57.3 MiB,``8940cdd621557bc55743d6bb4518c6d343a4587127e76de808fb07e51df03fea``
-   Python 3.7,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Windows-x86_64.exe>`_,55.8 MiB,``9c031506bfcb0428a0ac46c9152f9bdd48d5bdaa83046691bf8e0a4480663c05``
-   Python 3.9,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Windows-x86.exe>`_,55.3 MiB,``24f438e57ff2ef1ce1e93050d4e9d13f5050955f759f448d84a4018d3cd12d6b``
-   Python 3.8,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Windows-x86.exe>`_,54.5 MiB,``f81c165384c18d1986e2ba2f86cef384bc62266c46b34cd3d274e751ff5d91ed``
-   Python 3.7,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Windows-x86.exe>`_,52.9 MiB,``a1bb8338be12ee09dbd4cab9dcc2fbdc99f65d99281dd2c07d24ad0f23dd1f7c``
+   Python 3.9,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Windows-x86_64.exe>`_,70.4 MiB,``6013152b169c2c2d4bcd75bb03a1b8bf208b8545d69116a59351af695d9a0081``
+   Python 3.8,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-Windows-x86_64.exe>`_,69.8 MiB,``29d8d1720034df262b079514e5f200140f7303b37bfe90ae8a2b40b8f294d2d8``
+   Python 3.7,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-Windows-x86_64.exe>`_,68.1 MiB,``0b4890b2b1782c91ae2de2f77a2f6c5cecb9b54729565771f5301c1fc60fa024``
+   Python 3.9,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Windows-x86.exe>`_,66.5 MiB,``12a3a7e8aab7a974705ea4ee5bfc44f7c733241dd1b022f8012cbd42309b8472``
+   Python 3.8,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-Windows-x86.exe>`_,65.6 MiB,``df115c77915519a9a4de9c04ca26f81703be6ac0344762023557fc7659659ac0``
+   Python 3.7,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-Windows-x86.exe>`_,64.2 MiB,``64a18114bc66aaa73f431ef8ca1edc7b16ad5564a16e18f13e1a69272d85ca5d``
 
 
 macOS installers
@@ -68,13 +68,13 @@ macOS installers
    :header: Python version,Name,Size,SHA256 hash
    :widths: 5, 10, 5, 80
 
-   Python 3.9,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-MacOSX-x86_64.sh>`_,42.3 MiB,``786de9721f43e2c7d2803144c635f5f6e4823483536dc141ccd82dbb927cd508``
-   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-MacOSX-x86_64.pkg>`_,49.9 MiB,``8fa371ae97218c3c005cd5f04b1f40156d1506a9bd1d5c078f89d563fd416816``
-   Python 3.8,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-MacOSX-x86_64.sh>`_,53.3 MiB,``93e514e01142866629175f5a9e2e1d0bac8bc705f61d1ed1da3c010b7225683a``
-   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-MacOSX-x86_64.pkg>`_,60.8 MiB,``faab44cd21b4b09f5c032aa49a8a23d3c53ef629dc9322411348ce413e41df35``
+   Python 3.9,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-MacOSX-x86_64.sh>`_,55.2 MiB,``7717253055e7c09339cd3d0815a0b1986b9138dcfcb8ec33b9733df32dd40eaa``
+   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-MacOSX-x86_64.pkg>`_,61.9 MiB,``d3e63d7e8aa3ffb7b095e0b984db47309bb1cb1ec2138f5e6a96a34173671451``
+   Python 3.8,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-MacOSX-x86_64.sh>`_,55.7 MiB,``e13a4590879638197b0c506768438406b07de614911610e314f8c78133915b1c``
+   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-MacOSX-x86_64.pkg>`_,62.4 MiB,``3ca9720a2b47fbbff529057fd4ec8781a23cb825eec289b487dfa040b7ae8e25``
    ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.1-MacOSX-arm64.sh>`_,44.9 MiB,``4ce4047065f32e991edddbb63b3c7108e7f4534cfc1efafc332454a414deab58``
-   Python 3.7,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-MacOSX-x86_64.sh>`_,50.6 MiB,``ca7492d456c319d15682b2d3845112a631365f293d38d1f62872c33a2e57e430``
-   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-MacOSX-x86_64.pkg>`_,58.1 MiB,``c3710f25748884741ef8d97777ebb3541c992d51130298830b5b9ad449dbbf1e``
+   Python 3.7,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-MacOSX-x86_64.sh>`_,63.5 MiB,``c3a863eb85ad7035e5578684509b0b8387e8eb93c022495ab987baac3df6ef41``
+   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-MacOSX-x86_64.pkg>`_,70.2 MiB,``e28d2edb8d79b884f9f35479d35635b2d3d415f3af634b39043aff4ed14a0458``
 
 Linux installers
 ================
@@ -83,17 +83,17 @@ Linux installers
    :header: Python version,Name,Size,SHA256 hash
    :widths: 5, 10, 5, 80
 
-   Python 3.9,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Linux-x86_64.sh>`_,63.6 MiB,``1ea2f885b4dbc3098662845560bc64271eb17085387a70c2ba3f29fff6f8d52f``
-   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Linux-aarch64.sh>`_,62.6 MiB,``4879820a10718743f945d88ef142c3a4b30dfc8e448d1ca08e019586374b773f``
-   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Linux-ppc64le.sh>`_,60.6 MiB,``fa92ee4773611f58ed9333f977d32bbb64769292f605d518732183be1f3321fa``
+   Python 3.9,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-x86_64.sh>`_,72.2 MiB,``4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4``
+   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-aarch64.sh>`_,74.4 MiB,``00c7127a8a8d3f4b9c2ab3391c661239d5b9a88eafe895fd0f3f2a8d9c0f4556``
+   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-ppc64le.sh>`_,73.5 MiB,``8ee1f8d17ef7c8cb08a85f7d858b1cb55866c06fcf7545b98c3b82e4d0277e66``
    ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Linux-s390x.sh>`_,57.1 MiB,``1faed9abecf4a4ddd4e0d8891fc2cdaa3394c51e877af14ad6b9d4aadb4e90d8``
-   Python 3.8,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh>`_,98.8 MiB,``935d72deb16e42739d69644977290395561b7a6db059b316958d97939e9bdf3d``
-   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-aarch64.sh>`_,94.8 MiB,``19584b4fb5c0656e0cf9de72aaa0b0a7991fbd6f1254d12e2119048c9a47e5cc``
-   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-ppc64le.sh>`_,93.3 MiB,``c1ac79540cb77b2e0ca5b9f78b3bc367567d810118500a167dea4a0bcab5d063``
+   Python 3.8,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-Linux-x86_64.sh>`_,71.7 MiB,``4bb91089ecc5cc2538dece680bfe2e8192de1901e5e420f63d4e78eb26b0ac1a``
+   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-Linux-aarch64.sh>`_,63.6 MiB,``607549f9f9c5c703be850fa3025e845656d275d8226b679faf3b1c1813c692ce``
+   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-Linux-ppc64le.sh>`_,65.2 MiB,``2f606bd65ffe76a7866bc445d96105d0a15b7447e59e4317d2e017f7786272d0``
    ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-s390x.sh>`_,89.0 MiB,``55f514110a50e98549a68912cbb03e43a36193940a1889e1c8beb30009b4da19``
-   Python 3.7,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh>`_,84.9 MiB,``a1a7285dea0edc430b2bc7951d89bb30a2a1b32026d2a7b02aacaaa95cf69c7c``
-   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Linux-aarch64.sh>`_,89.2 MiB,``65f400a906e3132ddbba35a38d619478be77d32210a2acab05133d92ba08f111``
-   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Linux-ppc64le.sh>`_,88.1 MiB,``e4f8b4a5eb8da1badf0b0c91fd7ee25e39120d4d77443e7a1ef3661fd439a997``
+   Python 3.7,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-Linux-x86_64.sh>`_,98.9 MiB,``745c99af2cb0d0e0f43c7ed1a3417ff4d5118eafb501518120ea30361f1bb8f6``
+   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-Linux-aarch64.sh>`_,100.9 MiB,``736bd228d336f4b2d16cdc94f2e08a5c80c18dc42b0edfc59fe3f66ffb93a87d``
+   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-Linux-ppc64le.sh>`_,101.0 MiB,``041ba0d993398200b3e7f88aee862a23a7cb4ca8ddafbc9d74f8aabb0a5747db``
    ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Linux-s390x.sh>`_,84.1 MiB,``7ab9f813dd84cb0951a2d755cd84708263ce4e03c656e65e2fa79ed0f024f0f7``
 
 Installing

--- a/docs/source/miniconda.rst.jinja2
+++ b/docs/source/miniconda.rst.jinja2
@@ -32,7 +32,7 @@ which does require administrator permissions.
 Latest Miniconda Installer Links
 ================================
 
-.. csv-table:: Latest - Conda {{ conda_version }} Python 3.9.5 released July 21, 2021
+.. csv-table:: Latest - Conda {{ conda_version }} Python 3.9.7 released February 15, 2022
    :header: Platform,Name,SHA256 hash
    :widths: 5, 10, 80
 
@@ -44,7 +44,7 @@ Latest Miniconda Installer Links
    Linux,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,``{{ linux64_py3_latest_hash }}``
    ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh>`_,``{{ linux_aarch64_py3_latest_hash }}``
    ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`_,``{{ linux_ppc64le_py3_latest_hash }}``
-   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-s390x.sh>`_,``{{ linux_s390x_py3_latest_hash }}``
+   ,`Miniconda3 Linux-s390x 64-bit (conda 4.10.3 2021-07-21) <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-s390x.sh>`_,``{{ linux_s390x_py3_latest_hash }}``
 
 Windows installers
 ==================

--- a/docs/source/miniconda.rst.jinja2
+++ b/docs/source/miniconda.rst.jinja2
@@ -9,10 +9,42 @@ Miniconda
 Miniconda is a free minimal installer for conda. It is a small, bootstrap
 version of Anaconda that includes only conda, Python, the packages they depend
 on, and a small number of other useful packages, including pip, zlib and a
-few others. Use the ``conda install command`` to install 720+ additional conda
+few others. Use the ``conda install`` command to install 720+ additional conda
 packages from the Anaconda repository.
 
 `See if Miniconda is right for you <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html#anaconda-or-miniconda>`_.
+
+System requirements
+===================
+
+* License: Free use and redistribution under the terms of the `EULA for Miniconda <https://www.anaconda.com/end-user-license-agreement-miniconda>`_.
+* Operating system: Windows 8 or newer, 64-bit macOS 10.13+, or Linux, including Ubuntu, RedHat, CentOS 7+, and others.
+* If your operating system is older than what is currently supported, you can find older versions of the Miniconda installers in our `archive <https://repo.anaconda.com/miniconda/>`_ that might work for you.
+* System architecture: Windows- 64-bit x86, 32-bit x86; macOS- 64-bit x86 & Apple M1 (ARM64); Linux- 64-bit x86, 64-bit aarch64 (AWS Graviton2 / ARM64), 64-bit IBM Power8/Power9, s390x (Linux on IBM Z & LinuxONE).
+* The ``linux-aarch64`` Miniconda installer requires ``glibc >=2.26`` and thus will **not** work with CentOS 7, Ubuntu 16.04, or Debian 9 ("stretch").
+* Minimum 400 MB disk space to download and install.
+
+On Windows, macOS, and Linux, it is best to install Miniconda for the local user,
+which does not require administrator permissions and is the most robust type of
+installation. However, if you need to, you can install Miniconda system wide,
+which does require administrator permissions.
+
+Latest Miniconda Installer Links
+================================
+
+.. csv-table:: Latest - Conda {{ conda_version }} Python 3.9.5 released July 21, 2021
+   :header: Platform,Name,SHA256 hash
+   :widths: 5, 10, 80
+
+   Windows,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_,``{{ win64_py3_latest_hash }}``
+   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe>`_,``{{ win32_py3_latest_hash }}``
+   MacOSX,`Miniconda3 MacOSX 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh>`_,``{{ osx64_sh_py3_latest_hash }}``
+   ,`Miniconda3 MacOSX 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_,``{{ osx64_pkg_py3_latest_hash }}``
+   ,`Miniconda3 macOS Apple M1 64-bit bash (Py38 conda 4.10.1 2021-11-08) <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh>`_,``{{ osx_arm64_sh_py3_latest_hash }}``
+   Linux,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,``{{ linux64_py3_latest_hash }}``
+   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh>`_,``{{ linux_aarch64_py3_latest_hash }}``
+   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`_,``{{ linux_ppc64le_py3_latest_hash }}``
+   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-s390x.sh>`_,``{{ linux_s390x_py3_latest_hash }}``
 
 Windows installers
 ==================
@@ -21,23 +53,28 @@ Windows installers
    :header: Python version,Name,Size,SHA256 hash
    :widths: 5, 10, 5, 80
 
-   Python 3.8,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_,{{ win64_py3_size }},``{{ win64_py3_hash }}``
-   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe>`_,{{ win32_py3_size }},``{{ win32_py3_hash}}``
-   Python 2.7,`Miniconda2 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Windows-x86_64.exe>`_,{{ win64_py2_size }},``{{ win64_py2_hash }}``
-   ,`Miniconda2 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Windows-x86.exe>`_,{{ win32_py2_size }},``{{ win32_py2_hash }}``
+   Python 3.9,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-Windows-x86_64.exe>`_,{{ win64_py39_size }},``{{ win64_py39_hash }}``
+   Python 3.8,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-Windows-x86_64.exe>`_,{{ win64_py38_size }},``{{ win64_py38_hash }}``
+   Python 3.7,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-Windows-x86_64.exe>`_,{{ win64_py37_size }},``{{ win64_py37_hash }}``
+   Python 3.9,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-Windows-x86.exe>`_,{{ win32_py39_size }},``{{ win32_py39_hash }}``
+   Python 3.8,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-Windows-x86.exe>`_,{{ win32_py38_size }},``{{ win32_py38_hash }}``
+   Python 3.7,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-Windows-x86.exe>`_,{{ win32_py37_size }},``{{ win32_py37_hash }}``
 
 
-MacOSX installers
+macOS installers
 =================
 
-.. csv-table:: MacOSX
+.. csv-table:: macOS
    :header: Python version,Name,Size,SHA256 hash
    :widths: 5, 10, 5, 80
 
-   Python 3.8,`Miniconda3 MacOSX 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh>`_,{{ osx64_sh_py3_size }},``{{ osx64_sh_py3_hash }}``
-   ,`Miniconda3 MacOSX 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py3_size }},``{{ osx64_pkg_py3_hash }}``
-   Python 2.7,`Miniconda2 MacOSX 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda2-latest-MacOSX-x86_64.sh>`_,{{ osx64_sh_py2_size }},``{{ osx64_sh_py2_hash }}``
-   ,`Miniconda2 MacOSX 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda2-latest-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py2_size }},``{{ osx64_pkg_py2_hash }}``
+   Python 3.9,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py39_size }},``{{ osx64_sh_py39_hash }}``
+   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py39_size }},``{{ osx64_pkg_py39_hash }}``
+   Python 3.8,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py38_size }},``{{ osx64_sh_py38_hash }}``
+   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py38_size }},``{{ osx64_pkg_py38_hash }}``
+   ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.1-MacOSX-arm64.sh>`_,44.9 MiB,``4ce4047065f32e991edddbb63b3c7108e7f4534cfc1efafc332454a414deab58``
+   Python 3.7,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py37_size }},``{{ osx64_sh_py37_hash }}``
+   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py37_size }},``{{ osx64_pkg_py37_hash }}``
 
 Linux installers
 ================
@@ -46,10 +83,18 @@ Linux installers
    :header: Python version,Name,Size,SHA256 hash
    :widths: 5, 10, 5, 80
 
-   Python 3.8,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,{{ linux64_py3_size}},``{{ linux64_py3_hash }}``
-   Python 3.7,`Miniconda3 Linux 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86.sh>`_,{{ linux32_py3_size }},``{{ linux32_py3_hash }}``
-   Python 2.7,`Miniconda2 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86_64.sh>`_,{{ linux64_py2_size }},``{{ linux64_py2_hash }}``
-   ,`Miniconda2 Linux 32-bit <https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86.sh>`_,{{ linux32_py2_size }},``{{ linux32_py2_hash }}``
+   Python 3.9,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-Linux-x86_64.sh>`_,{{ linux64_py39_size }},``{{ linux64_py39_hash }}``
+   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-Linux-aarch64.sh>`_,{{ linux_aarch64_py39_size }},``{{ linux_aarch64_py39_hash }}``
+   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-Linux-ppc64le.sh>`_,{{ linux_ppc64le_py39_size }},``{{ linux_ppc64le_py39_hash }}``
+   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-Linux-s390x.sh>`_,{{ linux_s390x_py39_size }},``{{ linux_s390x_py39_hash }}``
+   Python 3.8,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-Linux-x86_64.sh>`_,{{ linux64_py38_size }},``{{ linux64_py38_hash }}``
+   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-Linux-aarch64.sh>`_,{{ linux_aarch64_py38_size }},``{{ linux_aarch64_py38_hash }}``
+   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-Linux-ppc64le.sh>`_,{{ linux_ppc64le_py38_size }},``{{ linux_ppc64le_py38_hash }}``
+   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-Linux-s390x.sh>`_,{{ linux_s390x_py38_size }},``{{ linux_s390x_py38_hash }}``
+   Python 3.7,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-Linux-x86_64.sh>`_,{{ linux64_py37_size }},``{{ linux64_py37_hash }}``
+   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-Linux-aarch64.sh>`_,{{ linux_aarch64_py37_size }},``{{ linux_aarch64_py37_hash }}``
+   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-Linux-ppc64le.sh>`_,{{ linux_ppc64le_py37_size }},``{{ linux_ppc64le_py37_hash }}``
+   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-Linux-s390x.sh>`_,{{ linux_s390x_py37_size }},``{{ linux_s390x_py37_hash }}``
 
 Installing
 ==========
@@ -61,10 +106,8 @@ Installing
 Other resources
 ===============
 
- -  `Miniconda with Python 3.8 for Power8 &
+ -  `Miniconda with Python 3.9 for Power8 &
     Power9 <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`__
- -  `Miniconda with Python 2.7 for Power8 &
-    Power9 <https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-ppc64le.sh>`__
  -  `Miniconda Docker
     images <https://hub.docker.com/r/continuumio/>`__
  -  `Miniconda AWS
@@ -123,7 +166,7 @@ Other resources
     If you already have Miniconda or Anaconda
     installed, and you just want to upgrade, you should
     not use the installer. Just use ``conda update``.
- 
+
  For instance:
 
  .. container:: highlight-bash notranslate
@@ -135,3 +178,4 @@ Other resources
           $ conda update conda
 
  will update conda.
+

--- a/docs/source/miniconda.rst.jinja2
+++ b/docs/source/miniconda.rst.jinja2
@@ -106,8 +106,6 @@ Installing
 Other resources
 ===============
 
- -  `Miniconda with Python 3.9 for Power8 &
-    Power9 <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`__
  -  `Miniconda Docker
     images <https://hub.docker.com/r/continuumio/>`__
  -  `Miniconda AWS

--- a/docs/source/miniconda_hashes.rst
+++ b/docs/source/miniconda_hashes.rst
@@ -7,6 +7,27 @@ Miniconda hash information
 ==========================================   =========   ===================  ====================================================================
 Name                                         Size        Time modified        SHA256 hash                                                         
 ==========================================   =========   ===================  ====================================================================
+Miniconda3-py37_4.11.0-Linux-aarch64.sh      100.9 MiB   2022-02-15 12:57:07  ``736bd228d336f4b2d16cdc94f2e08a5c80c18dc42b0edfc59fe3f66ffb93a87d``
+Miniconda3-py37_4.11.0-Linux-ppc64le.sh      101.0 MiB   2022-02-15 12:57:07  ``041ba0d993398200b3e7f88aee862a23a7cb4ca8ddafbc9d74f8aabb0a5747db``
+Miniconda3-py37_4.11.0-Linux-x86_64.sh        98.9 MiB   2022-02-15 12:57:08  ``745c99af2cb0d0e0f43c7ed1a3417ff4d5118eafb501518120ea30361f1bb8f6``
+Miniconda3-py37_4.11.0-MacOSX-x86_64.pkg      70.2 MiB   2022-02-15 12:57:07  ``e28d2edb8d79b884f9f35479d35635b2d3d415f3af634b39043aff4ed14a0458``
+Miniconda3-py37_4.11.0-MacOSX-x86_64.sh       63.5 MiB   2022-02-15 12:57:08  ``c3a863eb85ad7035e5578684509b0b8387e8eb93c022495ab987baac3df6ef41``
+Miniconda3-py37_4.11.0-Windows-x86.exe        64.2 MiB   2022-02-15 12:57:07  ``64a18114bc66aaa73f431ef8ca1edc7b16ad5564a16e18f13e1a69272d85ca5d``
+Miniconda3-py37_4.11.0-Windows-x86_64.exe     68.1 MiB   2022-02-15 12:57:07  ``0b4890b2b1782c91ae2de2f77a2f6c5cecb9b54729565771f5301c1fc60fa024``
+Miniconda3-py38_4.11.0-Linux-aarch64.sh       63.6 MiB   2022-02-15 12:57:08  ``607549f9f9c5c703be850fa3025e845656d275d8226b679faf3b1c1813c692ce``
+Miniconda3-py38_4.11.0-Linux-ppc64le.sh       65.2 MiB   2022-02-15 12:57:08  ``2f606bd65ffe76a7866bc445d96105d0a15b7447e59e4317d2e017f7786272d0``
+Miniconda3-py38_4.11.0-Linux-x86_64.sh        71.7 MiB   2022-02-15 12:57:08  ``4bb91089ecc5cc2538dece680bfe2e8192de1901e5e420f63d4e78eb26b0ac1a``
+Miniconda3-py38_4.11.0-MacOSX-x86_64.pkg      62.4 MiB   2022-02-15 12:57:07  ``3ca9720a2b47fbbff529057fd4ec8781a23cb825eec289b487dfa040b7ae8e25``
+Miniconda3-py38_4.11.0-MacOSX-x86_64.sh       55.7 MiB   2022-02-15 12:57:07  ``e13a4590879638197b0c506768438406b07de614911610e314f8c78133915b1c``
+Miniconda3-py38_4.11.0-Windows-x86.exe        65.6 MiB   2022-02-15 12:57:07  ``df115c77915519a9a4de9c04ca26f81703be6ac0344762023557fc7659659ac0``
+Miniconda3-py38_4.11.0-Windows-x86_64.exe     69.8 MiB   2022-02-15 12:57:07  ``29d8d1720034df262b079514e5f200140f7303b37bfe90ae8a2b40b8f294d2d8``
+Miniconda3-py39_4.11.0-Linux-aarch64.sh       74.4 MiB   2022-02-15 12:57:08  ``00c7127a8a8d3f4b9c2ab3391c661239d5b9a88eafe895fd0f3f2a8d9c0f4556``
+Miniconda3-py39_4.11.0-Linux-ppc64le.sh       73.5 MiB   2022-02-15 12:57:07  ``8ee1f8d17ef7c8cb08a85f7d858b1cb55866c06fcf7545b98c3b82e4d0277e66``
+Miniconda3-py39_4.11.0-Linux-x86_64.sh        72.2 MiB   2022-02-15 12:57:08  ``4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4``
+Miniconda3-py39_4.11.0-MacOSX-x86_64.pkg      61.9 MiB   2022-02-15 12:57:07  ``d3e63d7e8aa3ffb7b095e0b984db47309bb1cb1ec2138f5e6a96a34173671451``
+Miniconda3-py39_4.11.0-MacOSX-x86_64.sh       55.2 MiB   2022-02-15 12:57:08  ``7717253055e7c09339cd3d0815a0b1986b9138dcfcb8ec33b9733df32dd40eaa``
+Miniconda3-py39_4.11.0-Windows-x86.exe        66.5 MiB   2022-02-15 12:57:07  ``12a3a7e8aab7a974705ea4ee5bfc44f7c733241dd1b022f8012cbd42309b8472``
+Miniconda3-py39_4.11.0-Windows-x86_64.exe     70.4 MiB   2022-02-15 12:57:08  ``6013152b169c2c2d4bcd75bb03a1b8bf208b8545d69116a59351af695d9a0081``
 Miniconda3-py37_4.10.3-Linux-aarch64.sh       89.2 MiB   2021-07-21 11:05:07  ``65f400a906e3132ddbba35a38d619478be77d32210a2acab05133d92ba08f111``
 Miniconda3-py37_4.10.3-Linux-ppc64le.sh       88.1 MiB   2021-07-21 11:05:08  ``e4f8b4a5eb8da1badf0b0c91fd7ee25e39120d4d77443e7a1ef3661fd439a997``
 Miniconda3-py37_4.10.3-Linux-s390x.sh         84.1 MiB   2021-07-21 11:05:08  ``7ab9f813dd84cb0951a2d755cd84708263ce4e03c656e65e2fa79ed0f024f0f7``

--- a/docs/source/miniconda_hashes.rst
+++ b/docs/source/miniconda_hashes.rst
@@ -35,6 +35,7 @@ Miniconda3-py37_4.10.1-Linux-aarch64.sh      104.5 MiB   2021-06-01 18:33:41  ``
 Miniconda3-py37_4.10.1-Linux-s390x.sh         84.1 MiB   2021-06-01 18:38:01  ``71957e590f6616096ef69c345f895603682305962d03889293ea937c3c56db94``
 Miniconda3-py38_4.10.1-Linux-aarch64.sh      111.1 MiB   2021-06-01 18:33:45  ``656998faeac584eac33abe90cbe3c7d0565a49031a4f5049d9e5311bb7b616fe``
 Miniconda3-py38_4.10.1-Linux-s390x.sh         89.0 MiB   2021-06-01 18:38:14  ``ebdff38ca1f8a6e994f78ab6108de09bb722633500980ab79c59ba9312443de5``
+Miniconda3-py38_4.10.1-MacOSX-arm64.sh        44.9 MiB   2021-11-08 08:57:47  ``4ce4047065f32e991edddbb63b3c7108e7f4534cfc1efafc332454a414deab58``
 Miniconda3-py39_4.10.1-Linux-aarch64.sh       69.8 MiB   2021-06-01 18:33:49  ``737687139c3e2aa43875b67f7d6915e412ac179f2e33e14f00e8b4e1f3d31dd7``
 Miniconda3-py39_4.10.1-Linux-s390x.sh         57.1 MiB   2021-06-01 18:38:17  ``afa5c587d2e9754a426da34ca032b41bee8fc5419881cc257ef7ee2e6e951c46``
 Miniconda3-py37_4.9.2-Linux-aarch64.sh       105.3 MiB   2021-03-16 18:15:18  ``ccbac800a2d897218dde1df3711d26299a083ca0beb118edf62cf8f3d9516da8``


### PR DESCRIPTION
The main items to review are:
- [docs/source/miniconda.rst](https://github.com/conda/conda-docs/pull/763/files#diff-bf39c6b7a444ad1746bc878d0cf4a70ba5f3a04a98157480014c9a0b105c280d)
- [docs/source/miniconda_hashes.rst](https://github.com/conda/conda-docs/pull/763/files#diff-42b4ad27a9a9abb860775608c0dfb18a2750b4a807af524bdcc1e0ed0d34b44c)

This is the Miniconda release for v4.11.0 which, at this time, includes:
- linux-64
- linux-aarch64
- linux-ppc64le
- osx-64
- win-32
- win-64

The changes to the `*.py` files and `*.jinja2` were to re-align the creation scripts with what has been manually edited in the docs files.

I was not sure who to add as a reviewer, so I added anyone who seemed to have been involved with Miniconda releases in the past.