### PR TITLE
Fix mailing lists links

### DIFF
--- a/docs/source/help-support.rst
+++ b/docs/source/help-support.rst
@@ -3,7 +3,7 @@ Help and support
 =================
 
 * Get free community support with our `Google group
-  <https://groups.google.com/a/continuum.io/forum/#!forum/anaconda>`_.
+  <https://groups.google.com/a/anaconda.com/forum/#!forum/anaconda>`_.
 
 * Paid `support <https://www.anaconda.com/support/>`_,
   `training <https://www.anaconda.com/training/>`_ and
@@ -24,9 +24,9 @@ Join the conda email group
 ===========================
 
 Join the mailing lists for both `Anaconda
-<https://groups.google.com/a/continuum.io/forum/#!forum/anaconda>`_
+<https://groups.google.com/a/anaconda.com/forum/#!forum/anaconda>`_
 and `conda
-<https://groups.google.com/a/continuum.io/forum/#!forum/conda>`_.
+<https://groups.google.com/a/anaconda.com/forum/#!forum/conda>`_.
 Ask questions, answer questions, discuss ways to use conda,
 request new features and submit any other comments you may have.
 


### PR DESCRIPTION
I'm not sure why the change in #713 was made, but today the new links are broken and the old ones still work. This reverts commit a36df9bf82a05b96d16577e1cc68f41b4a7cf926.