### PR TITLE
osx-arm64 updates

### DIFF
--- a/docs/source/miniconda.rst.jinja2
+++ b/docs/source/miniconda.rst.jinja2
@@ -38,9 +38,10 @@ Latest Miniconda Installer Links
 
    Windows,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_,``{{ win64_py3_latest_hash }}``
    ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe>`_,``{{ win32_py3_latest_hash }}``
-   MacOSX,`Miniconda3 MacOSX 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh>`_,``{{ osx64_sh_py3_latest_hash }}``
-   ,`Miniconda3 MacOSX 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_,``{{ osx64_pkg_py3_latest_hash }}``
+   macOS,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh>`_,``{{ osx64_sh_py3_latest_hash }}``
+   ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_,``{{ osx64_pkg_py3_latest_hash }}``
    ,`Miniconda3 macOS Apple M1 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh>`_,``{{ osx_arm64_sh_py3_latest_hash }}``
+   ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.pkg>`_,``{{ osx_arm64_pkg_py3_latest_hash }}``
    Linux,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,``{{ linux64_py3_latest_hash }}``
    ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh>`_,``{{ linux_aarch64_py3_latest_hash }}``
    ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`_,``{{ linux_ppc64le_py3_latest_hash }}``
@@ -68,16 +69,16 @@ macOS installers
    :header: Python version,Name,Size,SHA256 hash
    :widths: 5, 10, 5, 80
 
-   Python 3.9,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py39_size }},``{{ osx64_sh_py39_hash }}``
-   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py39_size }},``{{ osx64_pkg_py39_hash }}``
+   Python 3.9,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py39_size }},``{{ osx64_sh_py39_hash }}``
+   ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py39_size }},``{{ osx64_pkg_py39_hash }}``
    ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-MacOSX-arm64.sh>`_,{{ osx_arm64_sh_py39_size }},``{{ osx_arm64_sh_py39_hash }}``
    ,`Miniconda3 macOS Apple M1 ARM 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ conda_version }}-MacOSX-arm64.pkg>`_,{{ osx_arm64_pkg_py39_size }},``{{ osx_arm64_pkg_py39_hash }}``
-   Python 3.8,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py38_size }},``{{ osx64_sh_py38_hash }}``
-   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py38_size }},``{{ osx64_pkg_py38_hash }}``
+   Python 3.8,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py38_size }},``{{ osx64_sh_py38_hash }}``
+   ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py38_size }},``{{ osx64_pkg_py38_hash }}``
    ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-MacOSX-arm64.sh>`_,{{ osx_arm64_sh_py38_size }},``{{ osx_arm64_sh_py38_hash }}``
    ,`Miniconda3 macOS Apple M1 ARM 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ conda_version }}-MacOSX-arm64.pkg>`_,{{ osx_arm64_pkg_py38_size }},``{{ osx_arm64_pkg_py38_hash }}``
-   Python 3.7,`Miniconda3 macOS 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py37_size }},``{{ osx64_sh_py37_hash }}``
-   ,`Miniconda3 macOS 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py37_size }},``{{ osx64_pkg_py37_hash }}``
+   Python 3.7,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py37_size }},``{{ osx64_sh_py37_hash }}``
+   ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ conda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py37_size }},``{{ osx64_pkg_py37_hash }}``
 
 Linux installers
 ================


### PR DESCRIPTION
- Update jinja template to include osx-arm64 installers
- Fix names of macOS installers to make them consistent