### PR TITLE
Enable htmlzip as additional output format

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,3 +3,8 @@ version: 2
 python:
   install:
   - requirements: requirements.txt
+
+# Additional (downloadable) formats of the documentation to be built, apart
+# from the default HTML.
+formats:
+- htmlzip


### PR DESCRIPTION
This enables downloads for offline / air-gapped users, via e.g.

`wget https://readthedocs.com/projects/continuumio-conda-docs/downloads/htmlzip/latest/ -o conda.zip`