### PR TITLE
Updating copyright manually to the current year.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# (c) 2012-2017 Anaconda, Inc. / https://www.anaconda.com
+# (c) 2012-2022 Anaconda, Inc. / https://www.anaconda.com
 # All Rights Reserved
 #
 # conda is distributed under the terms of the BSD 3-clause license.
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Conda'
-copyright = u'2017, Anaconda, Inc.'
+copyright = u'2022, Anaconda, Inc.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Manually updating the copyright from 2017 to 2022, so the docs don't look abandoned.