### PR TITLE
Redirect to the latest stable release.

### DIFF
--- a/docs/source/conda-build.rst
+++ b/docs/source/conda-build.rst
@@ -3,4 +3,4 @@ Conda-build
 
 .. raw:: html
 
-        <html><head><meta http-equiv="refresh" content="0; URL='../../projects/conda-build/en/latest/'" /></head><body></body></html>
+        <html><head><meta http-equiv="refresh" content="0; URL='../../projects/conda-build/en/stable/'" /></head><body></body></html>

--- a/docs/source/conda.rst
+++ b/docs/source/conda.rst
@@ -3,4 +3,4 @@ Conda
 
 .. raw:: html
 
-        <html><head><meta http-equiv="refresh" content="0; URL='../../projects/conda/en/latest/'" /></head><body></body></html>
+        <html><head><meta http-equiv="refresh" content="0; URL='../../projects/conda/en/stable/'" /></head><body></body></html>

--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -12,7 +12,7 @@ on, and a small number of other useful packages, including pip, zlib and a
 few others. Use the ``conda install`` command to install 720+ additional conda
 packages from the Anaconda repository.
 
-`See if Miniconda is right for you <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html#anaconda-or-miniconda>`_.
+`See if Miniconda is right for you <https://docs.conda.io/projects/conda/en/stable/user-guide/install/download.html#anaconda-or-miniconda>`_.
 
 System requirements
 ===================
@@ -103,9 +103,9 @@ Linux installers
 Installing
 ==========
 - :doc:`See hashes for all Miniconda installers <../miniconda_hashes>`.
-- `Verify your installation <https://conda.io/projects/conda/en/latest/user-guide/install/download.html#cryptographic-hash-verification>`_.
+- `Verify your installation <https://conda.io/projects/conda/en/stable/user-guide/install/download.html#cryptographic-hash-verification>`_.
 - `Installation
-  instructions <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`__.
+  instructions <https://conda.io/projects/conda/en/stable/user-guide/install/index.html>`__.
 
 Other resources
 ===============

--- a/docs/source/miniconda.rst.jinja2
+++ b/docs/source/miniconda.rst.jinja2
@@ -12,7 +12,7 @@ on, and a small number of other useful packages, including pip, zlib and a
 few others. Use the ``conda install`` command to install 720+ additional conda
 packages from the Anaconda repository.
 
-`See if Miniconda is right for you <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html#anaconda-or-miniconda>`_.
+`See if Miniconda is right for you <https://docs.conda.io/projects/conda/en/stable/user-guide/install/download.html#anaconda-or-miniconda>`_.
 
 System requirements
 ===================
@@ -103,9 +103,9 @@ Linux installers
 Installing
 ==========
 - :doc:`See hashes for all Miniconda installers <../miniconda_hashes>`.
-- `Verify your installation <https://conda.io/projects/conda/en/latest/user-guide/install/download.html#cryptographic-hash-verification>`_.
+- `Verify your installation <https://conda.io/projects/conda/en/stable/user-guide/install/download.html#cryptographic-hash-verification>`_.
 - `Installation
-  instructions <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`__.
+  instructions <https://conda.io/projects/conda/en/stable/user-guide/install/index.html>`__.
 
 Other resources
 ===============

--- a/news/824-redirect-to-stable
+++ b/news/824-redirect-to-stable
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Links in the sidebar to the conda and conda-build documentation will point to the last stable release instead of the "latest" in-development version.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

When clicking on the "conda" link in the sidebar on docs.conda.io we get redirected to the "latest" version of the docs, which is the latest development version the main branch, and not the last release version that users may have. I suggest to change this to the "stable" version, which will also point to the last release.