### PR TITLE
Abstract miniconda.rst template

### DIFF
--- a/docs/source/create_miniconda_rst.py
+++ b/docs/source/create_miniconda_rst.py
@@ -6,7 +6,6 @@ See the miniconda.rst.jinja2 for the template that is ultimately rendered.
 NOTE: Please make sure to update the global variables below:
 - MINICONDA_VERSION
 - PYTHON_VERSION
-- RELEASE_DATE
 
 NOTE: Also confirm the PLATFORM_MAP is up-to-date.
 
@@ -14,6 +13,7 @@ NOTE: If a new Python variant has been built out, please update the tuple
 below for 'py_version'.
 """
 
+import datetime
 import urllib.request
 import json
 
@@ -26,7 +26,6 @@ FILES_URL = "https://repo.anaconda.com/miniconda/.files.json"
 # Update these!
 MINICONDA_VERSION = "23.3.1-0"
 PYTHON_VERSION = "3.10.10"  # This is the version of Python that's bundled into the Miniconda installers.
-RELEASE_DATE = "April 24, 2023"
 
 # Confirm these are up-to-date.
 PLATFORM_MAP = {
@@ -63,11 +62,14 @@ def get_latest_miniconda_sizes_and_hashes():
         "miniconda_version": MINICONDA_VERSION,
         "conda_version": MINICONDA_VERSION.split("-")[0],
         "python_version": PYTHON_VERSION,
-        "release_date": RELEASE_DATE
     }
 
     for platform_id, installer_suffix in PLATFORM_MAP.items():
         latest_installer = f"Miniconda3-latest-{installer_suffix}"
+        if "release_date" not in info:
+            mtime = data[latest_installer]["mtime"]
+            mdate = datetime.date.fromtimestamp(mtime)
+            info["release_date"] = mdate.strftime("%B %-d, %Y")
         info[f"{platform_id}_py3_latest_size"] = sizeof_fmt(data[latest_installer]["size"])
         info[f"{platform_id}_py3_latest_hash"] = data[latest_installer]["sha256"]
         for py_version in ("38", "39", "310"):

--- a/docs/source/create_miniconda_rst.py
+++ b/docs/source/create_miniconda_rst.py
@@ -26,19 +26,62 @@ FILES_URL = "https://repo.anaconda.com/miniconda/.files.json"
 # Update these!
 MINICONDA_VERSION = "23.3.1-0"
 PYTHON_VERSION = "3.10.10"  # This is the version of Python that's bundled into the Miniconda installers.
+# Must be sorted in the order in which they appear on the Miniconda page
+OPERATING_SYSTEMS = ("Windows", "macOS", "Linux")
+PY_VERSIONS = ("3.10", "3.9", "3.8")
 
 # Confirm these are up-to-date.
 PLATFORM_MAP = {
-    "win64": "Windows-x86_64.exe",
-    "win32": "Windows-x86.exe",
-    "osx64_sh": "MacOSX-x86_64.sh",
-    "osx64_pkg": "MacOSX-x86_64.pkg",
-    "osx_arm64_sh": "MacOSX-arm64.sh",
-    "osx_arm64_pkg": "MacOSX-arm64.pkg",
-    "linux64": "Linux-x86_64.sh",
-    "linux_aarch64": "Linux-aarch64.sh",
-    "linux_ppc64le": "Linux-ppc64le.sh",
-    "linux_s390x": "Linux-s390x.sh",
+    "win64": {
+        "operating_system": "Windows",
+        "suffix": "Windows-x86_64.exe",
+        "description": "Windows 64-bit",
+    },
+    "win32": {
+        "operating_system": "Windows",
+        "suffix": "Windows-x86.exe",
+        "description": "Windows 32-bit",
+    },
+    "osx64_sh": {
+        "operating_system": "macOS",
+        "suffix": "MacOSX-x86_64.sh",
+        "description": "macOS Intel x86 64-bit bash",
+    },
+    "osx64_pkg": {
+        "operating_system": "macOS",
+        "suffix": "MacOSX-x86_64.pkg",
+        "description": "macOS Intel x86 64-bit pkg",
+    },
+    "osx_arm64_sh": {
+        "operating_system": "macOS",
+        "suffix": "MacOSX-arm64.sh",
+        "description": "macOS Apple M1 64-bit bash",
+    },
+    "osx_arm64_pkg": {
+        "operating_system": "macOS",
+        "suffix": "MacOSX-arm64.pkg",
+        "description": "macOS Apple M1 64-bit pkg",
+    },
+    "linux64": {
+        "operating_system": "Linux",
+        "suffix": "Linux-x86_64.sh",
+        "description": "Linux 64-bit",
+    },
+    "linux_aarch64": {
+        "operating_system": "Linux",
+        "suffix": "Linux-aarch64.sh",
+        "description": "Linux-aarch64 64-bit",
+    },
+    "linux_ppc64le": {
+        "operating_system": "Linux",
+        "suffix": "Linux-ppc64le.sh",
+        "description": "Linux-ppc64le 64-bit",
+    },
+    "linux_s390x": {
+        "operating_system": "Linux",
+        "suffix": "Linux-s390x.sh",
+        "description": "Linux-s390x 64-bit",
+    },
 }
 
 
@@ -62,28 +105,40 @@ def get_latest_miniconda_sizes_and_hashes():
         "miniconda_version": MINICONDA_VERSION,
         "conda_version": MINICONDA_VERSION.split("-")[0],
         "python_version": PYTHON_VERSION,
+        "operating_systems": OPERATING_SYSTEMS,
+        "py_versions": PY_VERSIONS,
     }
+    info["platforms"] = {os: {"latest": []} for os in info["operating_systems"]}
 
-    for platform_id, installer_suffix in PLATFORM_MAP.items():
-        latest_installer = f"Miniconda3-latest-{installer_suffix}"
+    for platform_id, installer_data in PLATFORM_MAP.items():
+        latest_installer = f"Miniconda3-latest-{installer_data['suffix']}"
         if "release_date" not in info:
             mtime = data[latest_installer]["mtime"]
             mdate = datetime.date.fromtimestamp(mtime)
             info["release_date"] = mdate.strftime("%B %-d, %Y")
-        info[f"{platform_id}_py3_latest_size"] = sizeof_fmt(data[latest_installer]["size"])
-        info[f"{platform_id}_py3_latest_hash"] = data[latest_installer]["sha256"]
-        for py_version in ("38", "39", "310"):
-            full_installer = f"Miniconda3-py{py_version}_{MINICONDA_VERSION}-{installer_suffix}"
+        os = installer_data["operating_system"]
+        info["platforms"][os]["latest"].append(installer_data.copy())
+        info["platforms"][os]["latest"][-1]["hash"] = data[latest_installer]["sha256"]
+        for py_version in info["py_versions"]:
+            py = py_version.replace(".", "")
+            full_installer = (
+                f"Miniconda3-py{py}_{MINICONDA_VERSION}-{installer_data['suffix']}"
+            )
 
-            # win-32 is and will remain at "frozen" at v4.12.0 
+            # win-32 is and will remain at "frozen" at v4.12.0
             # (we no longer make new builds for this subdir)
             if platform_id == "win32":
-                full_installer = f"Miniconda3-py{py_version}_4.12.0-{installer_suffix}"
+                full_installer = f"Miniconda3-py{py}_4.12.0-{installer_data['suffix']}"
 
             if full_installer not in data:
                 continue
-            info[f"{platform_id}_py{py_version}_size"] = sizeof_fmt(data[full_installer]["size"])
-            info[f"{platform_id}_py{py_version}_hash"] = data[full_installer]["sha256"]
+            if py_version not in info["platforms"][os]:
+                info["platforms"][os][py_version] = [installer_data.copy()]
+            else:
+                info["platforms"][os][py_version].append(installer_data.copy())
+            installer = info["platforms"][os][py_version][-1]
+            installer["size"] = sizeof_fmt(data[full_installer]["size"])
+            installer["hash"] = data[full_installer]["sha256"]
 
     return info
 
@@ -96,7 +151,7 @@ def main():
 
     template = Template(template_text)
     rst_text = template.render(**rst_vars)
-    with open(OUT_FILENAME, 'w') as f:
+    with open(OUT_FILENAME, "w") as f:
         f.write(rst_text)
 
 

--- a/docs/source/create_miniconda_rst.py
+++ b/docs/source/create_miniconda_rst.py
@@ -139,6 +139,8 @@ def get_latest_miniconda_sizes_and_hashes():
             installer = info["platforms"][os,py_version][-1]
             installer["size"] = sizeof_fmt(data[full_installer]["size"])
             installer["hash"] = data[full_installer]["sha256"]
+            # full_installer item is needed until win-32 is removed
+            installer["full_installer"] = full_installer
 
     return info
 

--- a/docs/source/create_miniconda_rst.py
+++ b/docs/source/create_miniconda_rst.py
@@ -108,7 +108,7 @@ def get_latest_miniconda_sizes_and_hashes():
         "operating_systems": OPERATING_SYSTEMS,
         "py_versions": PY_VERSIONS,
     }
-    info["platforms"] = {os: {"latest": []} for os in info["operating_systems"]}
+    info["platforms"] = {(os,"latest"): [] for os in info["operating_systems"]}
 
     for platform_id, installer_data in PLATFORM_MAP.items():
         latest_installer = f"Miniconda3-latest-{installer_data['suffix']}"
@@ -117,8 +117,8 @@ def get_latest_miniconda_sizes_and_hashes():
             mdate = datetime.date.fromtimestamp(mtime)
             info["release_date"] = mdate.strftime("%B %-d, %Y")
         os = installer_data["operating_system"]
-        info["platforms"][os]["latest"].append(installer_data.copy())
-        info["platforms"][os]["latest"][-1]["hash"] = data[latest_installer]["sha256"]
+        info["platforms"][os,"latest"].append(installer_data.copy())
+        info["platforms"][os,"latest"][-1]["hash"] = data[latest_installer]["sha256"]
         for py_version in info["py_versions"]:
             py = py_version.replace(".", "")
             full_installer = (
@@ -132,11 +132,11 @@ def get_latest_miniconda_sizes_and_hashes():
 
             if full_installer not in data:
                 continue
-            if py_version not in info["platforms"][os]:
-                info["platforms"][os][py_version] = [installer_data.copy()]
+            if (os, py_version) not in info["platforms"]:
+                info["platforms"][os,py_version] = [installer_data.copy()]
             else:
-                info["platforms"][os][py_version].append(installer_data.copy())
-            installer = info["platforms"][os][py_version][-1]
+                info["platforms"][os,py_version].append(installer_data.copy())
+            installer = info["platforms"][os,py_version][-1]
             installer["size"] = sizeof_fmt(data[full_installer]["size"])
             installer["hash"] = data[full_installer]["sha256"]
 

--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -56,9 +56,9 @@ Windows installers
 
    Python 3.10,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Windows-x86_64.exe>`_,53.9 MiB,``307194e1f12bbeb52b083634e89cc67db4f7980bd542254b43d3309eaf7cb358``
    Python 3.9,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-Windows-x86_64.exe>`_,53.7 MiB,``155958e7922d8b7aa6cb3115aeb66d2efcdae1237a6f1c11e23ca75ea96d291a``
-   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-Windows-x86.exe>`_,67.8 MiB,``4fb64e6c9c28b88beab16994bfba4829110ea3145baa60bda5344174ab65d462``
+   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Windows-x86.exe>`_,67.8 MiB,``4fb64e6c9c28b88beab16994bfba4829110ea3145baa60bda5344174ab65d462``
    Python 3.8,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-Windows-x86_64.exe>`_,53.1 MiB,``f567b46b2312af5e60ec8f45daf9be626295b7716651e6e7434c447feea9123a``
-   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-Windows-x86.exe>`_,66.8 MiB,``60cc5874b3cce9d80a38fb2b28df96d880e8e95d1b5848b15c20f1181e2807db``
+   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Windows-x86.exe>`_,66.8 MiB,``60cc5874b3cce9d80a38fb2b28df96d880e8e95d1b5848b15c20f1181e2807db``
 
 macOS installers
 ================

--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -56,12 +56,12 @@ Windows installers
 
    Python 3.10,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Windows-x86_64.exe>`_,53.9 MiB,``307194e1f12bbeb52b083634e89cc67db4f7980bd542254b43d3309eaf7cb358``
    Python 3.9,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-Windows-x86_64.exe>`_,53.7 MiB,``155958e7922d8b7aa6cb3115aeb66d2efcdae1237a6f1c11e23ca75ea96d291a``
+   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-Windows-x86.exe>`_,67.8 MiB,``4fb64e6c9c28b88beab16994bfba4829110ea3145baa60bda5344174ab65d462``
    Python 3.8,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-Windows-x86_64.exe>`_,53.1 MiB,``f567b46b2312af5e60ec8f45daf9be626295b7716651e6e7434c447feea9123a``
-   Python 3.9,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Windows-x86.exe>`_,67.8 MiB,``4fb64e6c9c28b88beab16994bfba4829110ea3145baa60bda5344174ab65d462``
-   Python 3.8,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Windows-x86.exe>`_,66.8 MiB,``60cc5874b3cce9d80a38fb2b28df96d880e8e95d1b5848b15c20f1181e2807db``
+   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-Windows-x86.exe>`_,66.8 MiB,``60cc5874b3cce9d80a38fb2b28df96d880e8e95d1b5848b15c20f1181e2807db``
 
 macOS installers
-=================
+================
 
 .. csv-table:: macOS
    :header: Python version,Name,Size,SHA256 hash
@@ -69,16 +69,16 @@ macOS installers
 
    Python 3.10,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-MacOSX-x86_64.sh>`_,44.1 MiB,``5abc78b664b7da9d14ade330534cc98283bb838c6b10ad9cfd8b9cc4153f8104``
    ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-MacOSX-x86_64.pkg>`_,43.8 MiB,``cca31a0f1e5394f2b739726dc22551c2a19afdf689c13a25668887ba706cba58``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-MacOSX-arm64.sh>`_,42.6 MiB,``9d1d12573339c49050b0d5a840af0ff6c32d33c3de1b3db478c01878eb003d64``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-MacOSX-arm64.pkg>`_,42.3 MiB,``6997472c5ff90a772eb77e6397f4e3e227736c83a7f7b839da33d6cc7facb75d``
+   ,`Miniconda3 macOS Apple M1 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-MacOSX-arm64.sh>`_,42.6 MiB,``9d1d12573339c49050b0d5a840af0ff6c32d33c3de1b3db478c01878eb003d64``
+   ,`Miniconda3 macOS Apple M1 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-MacOSX-arm64.pkg>`_,42.3 MiB,``6997472c5ff90a772eb77e6397f4e3e227736c83a7f7b839da33d6cc7facb75d``
    Python 3.9,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-MacOSX-x86_64.sh>`_,44.4 MiB,``54d739715feb0cd5c127865215cc9f50697709d71e9ee7da430576c5a1c8010d``
    ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-MacOSX-x86_64.pkg>`_,44.1 MiB,``6960a11f74a0717adaacdc979d1817f5d0e3612d2ef7a409d547fbeac6d58ed7``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-MacOSX-arm64.sh>`_,43.0 MiB,``c74474bab188b8b3dcaf0f0ca52f5e0743591dbe171766016023d052acf96502``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-MacOSX-arm64.pkg>`_,42.7 MiB,``9bc8a8fde9d01e26ee37a6611a92a66d36db66ff82e76bd4f18cb28cfbad7a1f``
+   ,`Miniconda3 macOS Apple M1 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-MacOSX-arm64.sh>`_,43.0 MiB,``c74474bab188b8b3dcaf0f0ca52f5e0743591dbe171766016023d052acf96502``
+   ,`Miniconda3 macOS Apple M1 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-MacOSX-arm64.pkg>`_,42.7 MiB,``9bc8a8fde9d01e26ee37a6611a92a66d36db66ff82e76bd4f18cb28cfbad7a1f``
    Python 3.8,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-MacOSX-x86_64.sh>`_,44.2 MiB,``eb7b2d285f6d3b7c9cde9576c8c647e70b65361426b0e0e069b4ab23ccbb79e2``
    ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-MacOSX-x86_64.pkg>`_,43.9 MiB,``23d6fa672be46632abd0bbed1f12ce9542a6cb4a38922dab503d9a6096d186d3``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-MacOSX-arm64.sh>`_,42.9 MiB,``e0151c68f6a11a38b29c2f4a775bf6a22187fa2c8ca0f31930d69f2f013c0810``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-MacOSX-arm64.pkg>`_,42.6 MiB,``6714fdefd12e1a65c7fd344f3829a4b054ae42d3d1368b07ceeab9dcc41ad48b``
+   ,`Miniconda3 macOS Apple M1 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-MacOSX-arm64.sh>`_,42.9 MiB,``e0151c68f6a11a38b29c2f4a775bf6a22187fa2c8ca0f31930d69f2f013c0810``
+   ,`Miniconda3 macOS Apple M1 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-MacOSX-arm64.pkg>`_,42.6 MiB,``6714fdefd12e1a65c7fd344f3829a4b054ae42d3d1368b07ceeab9dcc41ad48b``
 
 Linux installers
 ================

--- a/docs/source/miniconda.rst.jinja2
+++ b/docs/source/miniconda.rst.jinja2
@@ -35,79 +35,29 @@ Latest Miniconda Installer Links
 .. csv-table:: Latest - Conda {{ conda_version }} Python {{ python_version }} released {{ release_date }}
    :header: Platform,Name,SHA256 hash
    :widths: 5, 10, 80
+{% for os in operating_systems %}
+  {%- for platform in platforms[os]['latest'] %}
+   {% set first_column = os if loop.first else "" -%}
+   {{ first_column }},`Miniconda3 {{ platform['description'] }} <https://repo.anaconda.com/miniconda/Miniconda3-latest-{{ platform['suffix'] }}>`_,``{{ platform['hash'] }}``
+  {%- endfor -%}
+{%- endfor -%}
 
-   Windows,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_,``{{ win64_py3_latest_hash }}``
-   ,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86.exe>`_,``{{ win32_py3_latest_hash }}``
-   macOS,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh>`_,``{{ osx64_sh_py3_latest_hash }}``
-   ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_,``{{ osx64_pkg_py3_latest_hash }}``
-   ,`Miniconda3 macOS Apple M1 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh>`_,``{{ osx_arm64_sh_py3_latest_hash }}``
-   ,`Miniconda3 macOS Apple M1 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.pkg>`_,``{{ osx_arm64_pkg_py3_latest_hash }}``
-   Linux,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh>`_,``{{ linux64_py3_latest_hash }}``
-   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh>`_,``{{ linux_aarch64_py3_latest_hash }}``
-   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh>`_,``{{ linux_ppc64le_py3_latest_hash }}``
-   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-s390x.sh>`_,``{{ linux_s390x_py3_latest_hash }}``
+{%- for os in operating_systems %}
+{% set heading = "{} installers".format(os) %}
+{{ heading }}
+{{ "=" * heading|length }}
 
-Windows installers
-==================
-
-.. csv-table:: Windows
+.. csv-table:: {{ os }}
    :header: Python version,Name,Size,SHA256 hash
    :widths: 5, 10, 5, 80
-
-   Python 3.10,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py310_{{ miniconda_version }}-Windows-x86_64.exe>`_,{{ win64_py310_size }},``{{ win64_py310_hash }}``
-   Python 3.9,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ miniconda_version }}-Windows-x86_64.exe>`_,{{ win64_py39_size }},``{{ win64_py39_hash }}``
-   Python 3.8,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ miniconda_version }}-Windows-x86_64.exe>`_,{{ win64_py38_size }},``{{ win64_py38_hash }}``
-   Python 3.7,`Miniconda3 Windows 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ miniconda_version }}-Windows-x86_64.exe>`_,{{ win64_py37_size }},``{{ win64_py37_hash }}``
-   Python 3.9,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Windows-x86.exe>`_,{{ win32_py39_size }},``{{ win32_py39_hash }}``
-   Python 3.8,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Windows-x86.exe>`_,{{ win32_py38_size }},``{{ win32_py38_hash }}``
-   Python 3.7,`Miniconda3 Windows 32-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Windows-x86.exe>`_,{{ win32_py37_size }},``{{ win32_py37_hash }}``
-
-
-macOS installers
-=================
-
-.. csv-table:: macOS
-   :header: Python version,Name,Size,SHA256 hash
-   :widths: 5, 10, 5, 80
-
-   Python 3.10,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py310_{{ miniconda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py310_size }},``{{ osx64_sh_py310_hash }}``
-   ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py310_{{ miniconda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py310_size }},``{{ osx64_pkg_py310_hash }}``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py310_{{ miniconda_version }}-MacOSX-arm64.sh>`_,{{ osx_arm64_sh_py310_size }},``{{ osx_arm64_sh_py310_hash }}``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py310_{{ miniconda_version }}-MacOSX-arm64.pkg>`_,{{ osx_arm64_pkg_py310_size }},``{{ osx_arm64_pkg_py310_hash }}``
-   Python 3.9,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ miniconda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py39_size }},``{{ osx64_sh_py39_hash }}``
-   ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ miniconda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py39_size }},``{{ osx64_pkg_py39_hash }}``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ miniconda_version }}-MacOSX-arm64.sh>`_,{{ osx_arm64_sh_py39_size }},``{{ osx_arm64_sh_py39_hash }}``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ miniconda_version }}-MacOSX-arm64.pkg>`_,{{ osx_arm64_pkg_py39_size }},``{{ osx_arm64_pkg_py39_hash }}``
-   Python 3.8,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ miniconda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py38_size }},``{{ osx64_sh_py38_hash }}``
-   ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ miniconda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py38_size }},``{{ osx64_pkg_py38_hash }}``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ miniconda_version }}-MacOSX-arm64.sh>`_,{{ osx_arm64_sh_py38_size }},``{{ osx_arm64_sh_py38_hash }}``
-   ,`Miniconda3 macOS Apple M1 ARM 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ miniconda_version }}-MacOSX-arm64.pkg>`_,{{ osx_arm64_pkg_py38_size }},``{{ osx_arm64_pkg_py38_hash }}``
-   Python 3.7,`Miniconda3 macOS Intel x86 64-bit bash <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ miniconda_version }}-MacOSX-x86_64.sh>`_,{{ osx64_sh_py37_size }},``{{ osx64_sh_py37_hash }}``
-   ,`Miniconda3 macOS Intel x86 64-bit pkg <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ miniconda_version }}-MacOSX-x86_64.pkg>`_,{{ osx64_pkg_py37_size }},``{{ osx64_pkg_py37_hash }}``
-
-Linux installers
-================
-
-.. csv-table:: Linux
-   :header: Python version,Name,Size,SHA256 hash
-   :widths: 5, 10, 5, 80
-
-   Python 3.10,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py310_{{ miniconda_version }}-Linux-x86_64.sh>`_,{{ linux64_py310_size }},``{{ linux64_py310_hash }}``
-   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py310_{{ miniconda_version }}-Linux-aarch64.sh>`_,{{ linux_aarch64_py310_size }},``{{ linux_aarch64_py310_hash }}``
-   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py310_{{ miniconda_version }}-Linux-ppc64le.sh>`_,{{ linux_ppc64le_py310_size }},``{{ linux_ppc64le_py310_hash }}``
-   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py310_{{ miniconda_version }}-Linux-s390x.sh>`_,{{ linux_s390x_py310_size }},``{{ linux_s390x_py310_hash }}``
-   Python 3.9,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ miniconda_version }}-Linux-x86_64.sh>`_,{{ linux64_py39_size }},``{{ linux64_py39_hash }}``
-   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ miniconda_version }}-Linux-aarch64.sh>`_,{{ linux_aarch64_py39_size }},``{{ linux_aarch64_py39_hash }}``
-   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ miniconda_version }}-Linux-ppc64le.sh>`_,{{ linux_ppc64le_py39_size }},``{{ linux_ppc64le_py39_hash }}``
-   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ miniconda_version }}-Linux-s390x.sh>`_,{{ linux_s390x_py39_size }},``{{ linux_s390x_py39_hash }}``
-   Python 3.8,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ miniconda_version }}-Linux-x86_64.sh>`_,{{ linux64_py38_size }},``{{ linux64_py38_hash }}``
-   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ miniconda_version }}-Linux-aarch64.sh>`_,{{ linux_aarch64_py38_size }},``{{ linux_aarch64_py38_hash }}``
-   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ miniconda_version }}-Linux-ppc64le.sh>`_,{{ linux_ppc64le_py38_size }},``{{ linux_ppc64le_py38_hash }}``
-   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py38_{{ miniconda_version }}-Linux-s390x.sh>`_,{{ linux_s390x_py38_size }},``{{ linux_s390x_py38_hash }}``
-   Python 3.7,`Miniconda3 Linux 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ miniconda_version }}-Linux-x86_64.sh>`_,{{ linux64_py37_size }},``{{ linux64_py37_hash }}``
-   ,`Miniconda3 Linux-aarch64 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ miniconda_version }}-Linux-aarch64.sh>`_,{{ linux_aarch64_py37_size }},``{{ linux_aarch64_py37_hash }}``
-   ,`Miniconda3 Linux-ppc64le 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ miniconda_version }}-Linux-ppc64le.sh>`_,{{ linux_ppc64le_py37_size }},``{{ linux_ppc64le_py37_hash }}``
-   ,`Miniconda3 Linux-s390x 64-bit <https://repo.anaconda.com/miniconda/Miniconda3-py37_{{ miniconda_version }}-Linux-s390x.sh>`_,{{ linux_s390x_py37_size }},``{{ linux_s390x_py37_hash }}``
+{% for py_version in py_versions %}
+  {%- set py = py_version|replace(".", "") -%}
+  {%- for platform in platforms[os][py_version] %}
+   {% set first_column = "Python {}".format(py_version) if loop.first else "" -%}
+   {{ first_column }},`Miniconda3 {{ platform['description'] }} <https://repo.anaconda.com/miniconda/Miniconda3-py{{ py }}_{{ miniconda_version}}-{{ platform['suffix'] }}>`_,{{ platform['size'] }},``{{ platform['hash'] }}``
+  {%- endfor -%}
+{%- endfor %}
+{%- endfor %}
 
 Installing
 ==========

--- a/docs/source/miniconda.rst.jinja2
+++ b/docs/source/miniconda.rst.jinja2
@@ -36,7 +36,7 @@ Latest Miniconda Installer Links
    :header: Platform,Name,SHA256 hash
    :widths: 5, 10, 80
 {% for os in operating_systems %}
-  {%- for platform in platforms[os]['latest'] %}
+  {%- for platform in platforms[os,'latest'] %}
    {% set first_column = os if loop.first else "" -%}
    {{ first_column }},`Miniconda3 {{ platform['description'] }} <https://repo.anaconda.com/miniconda/Miniconda3-latest-{{ platform['suffix'] }}>`_,``{{ platform['hash'] }}``
   {%- endfor -%}
@@ -52,7 +52,7 @@ Latest Miniconda Installer Links
    :widths: 5, 10, 5, 80
 {% for py_version in py_versions %}
   {%- set py = py_version|replace(".", "") -%}
-  {%- for platform in platforms[os][py_version] %}
+  {%- for platform in platforms[os,py_version] %}
    {% set first_column = "Python {}".format(py_version) if loop.first else "" -%}
    {{ first_column }},`Miniconda3 {{ platform['description'] }} <https://repo.anaconda.com/miniconda/Miniconda3-py{{ py }}_{{ miniconda_version}}-{{ platform['suffix'] }}>`_,{{ platform['size'] }},``{{ platform['hash'] }}``
   {%- endfor -%}

--- a/docs/source/miniconda.rst.jinja2
+++ b/docs/source/miniconda.rst.jinja2
@@ -54,7 +54,7 @@ Latest Miniconda Installer Links
   {%- set py = py_version|replace(".", "") -%}
   {%- for platform in platforms[os,py_version] %}
    {% set first_column = "Python {}".format(py_version) if loop.first else "" -%}
-   {{ first_column }},`Miniconda3 {{ platform['description'] }} <https://repo.anaconda.com/miniconda/Miniconda3-py{{ py }}_{{ miniconda_version}}-{{ platform['suffix'] }}>`_,{{ platform['size'] }},``{{ platform['hash'] }}``
+   {{ first_column }},`Miniconda3 {{ platform['description'] }} <https://repo.anaconda.com/miniconda/{{ platform['full_installer'] }}>`_,{{ platform['size'] }},``{{ platform['hash'] }}``
   {%- endfor -%}
 {%- endfor %}
 {%- endfor %}


### PR DESCRIPTION
### Description

The current `jinja2` template requires a lot of manual labor to update. To remove or add a python version, the template needs to be changed in multiple places *and* the `create_miniconda_rst.py` file needs to be updated, which is error prone. Currently, `miniconda.rst` does not correspond to the `jinja2` file anymore either.

This PR abstracts the `jinja2` template to minimize the number of changes needed for updating the release tables.

Changes:
* Abstract the `jinja2` template for Miniconda installers
* Get the release date from the time stamps stored in the `files.json` file.

Notable differences in the output:
* The `AMD` part for Apple M1 installers is removed and is now consistent with the "latest" Miniconda description.
* The Windows installers are rearranged to be formatted like Linux and macOS.

### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?