### PR TITLE
Fix flags on downloading with wget.

### DIFF
--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -90,7 +90,7 @@ These quick command line instructions will get you set up quickly with the lates
       .. code-block:: bash
 
          mkdir -p ~/miniconda3
-         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o ~/miniconda3/miniconda.sh
+         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
          bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
          rm -rf ~/miniconda3/miniconda.sh
 

--- a/docs/source/miniconda.rst.jinja2
+++ b/docs/source/miniconda.rst.jinja2
@@ -85,7 +85,7 @@ These quick command line instructions will get you set up quickly with the lates
       .. code-block:: bash
 
          mkdir -p ~/miniconda3
-         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o ~/miniconda3/miniconda.sh
+         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
          bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
          rm -rf ~/miniconda3/miniconda.sh
 


### PR DESCRIPTION
The wget  `-o` flag puts the standard out to the file, `-O` actually writes the content to the file.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I just tried to install miniconda and hit this bug (looks like it was introduced recently).

<img width="1125" alt="Screenshot 2023-08-23 at 12 21 08" src="https://github.com/conda/conda-docs/assets/6815729/ccebd768-2f67-4a86-bb7b-71b71f9cb015">

<img width="1666" alt="Screenshot 2023-08-23 at 12 22 00" src="https://github.com/conda/conda-docs/assets/6815729/81c71be5-f251-497b-bf10-b2f3464c5912">

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
