### PR TITLE
Change -o flag to -O in wget command in miniconda.rst

### DIFF
--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -90,7 +90,7 @@ These quick command line instructions will get you set up quickly with the lates
       .. code-block:: bash
 
          mkdir -p ~/miniconda3
-         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o ~/miniconda3/miniconda.sh
+         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
          bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
          rm -rf ~/miniconda3/miniconda.sh
 


### PR DESCRIPTION
Change -o flag to -O in wget command

### Description

-o means to capture wget messages to the file. What we actually want here is to output the downloaded file to a file, which requires the -O flag. This tripped me up. I've updated the documentation accordingly.
