### PR TITLE
Fixed command typo in Miniconda Mac install

### DIFF
--- a/docs/source/miniconda.rst
+++ b/docs/source/miniconda.rst
@@ -74,7 +74,7 @@ These quick command line instructions will get you set up quickly with the lates
          mkdir -p ~/miniconda3
          curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -o ~/miniconda3/miniconda.sh
          bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-         rm -rf ~miniconda3/miniconda.sh
+         rm -rf ~/miniconda3/miniconda.sh
 
       After installing, initialize your newly-installed Miniconda. The following commands initialize for bash and zsh shells:
 


### PR DESCRIPTION
rm -rf ~miniconda3/miniconda.sh

this is not a proper path it should have been a ~/

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

small path fix in the command
<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
