### PR TITLE
Fix icon links still wrong due to override

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -138,15 +138,9 @@ html_theme_options = {
     "goatcounter_url": "https://docs-conda-io.goatcounter.com/count",
     "icon_links": [
         {
-            "name": "Element",
-            "url": "https://matrix.to/#/#conda:matrix.org",
-            "icon": "_static/element_logo.svg",
-            "type": "local",
-        },
-        {
-            "name": "Discourse",
-            "url": "https://conda.discourse.group/",
-            "icon": "fa-brands fa-discourse",
+            "name": "Zulip",
+            "url": "https://conda.zulipchat.com",
+            "icon": "fa-custom fa-zulip",
             "type": "fontawesome",
         },
     ],


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
As a follow up to #1001, I didn't realize that we were overriding the icon links from this repo. It is required because we are setting a separate `github_url`, which causes the theme's default icons to be skipped. This PR changes the overrides to add in the Zulip icon.


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-docs/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-docs/blob/main/CONTRIBUTING.md -->
